### PR TITLE
Only cancel scan if job is cancelled and ignore cancel output

### DIFF
--- a/cxAstScan/services/CleanUpRunner.ts
+++ b/cxAstScan/services/CleanUpRunner.ts
@@ -1,37 +1,41 @@
 import * as taskLib from "azure-pipelines-task-lib/task";
 import {promises as fs} from 'fs';
 import {CxWrapper} from "@checkmarxdev/ast-cli-javascript-wrapper";
-import {CxCommandOutput} from "@checkmarxdev/ast-cli-javascript-wrapper/dist/main/wrapper/CxCommandOutput";
 import { getConfiguration, getLogFilename } from "./Utils";
 
 export class CleanUpRunner {
-    async run() {;
+    async run() {
+        console.log("Getting job status");
+        const jobStatus = taskLib.getVariable('AGENT_JOBSTATUS');
+        console.log("Job status: " + jobStatus);
+        if (jobStatus !== 'Canceled') {
+            console.log("Pipeline not cancelled, nothing to do.");
+            taskLib.setResult(taskLib.TaskResult.Succeeded, "");
+            return;
+        }
+
         const cxScanConfig = getConfiguration();
         const wrapper = new CxWrapper(cxScanConfig);
 
         const data = await fs.readFile(getLogFilename(), 'utf8');
-        
+
         //Regex to get the scanID ofthe logs
-        var regexScanId = new RegExp(/"(ID)":"((\\"|[^"])*)"/i);
-        var regexArray: RegExpExecArray | null
-        
+        const regexScanId = new RegExp(/"(ID)":"((\\"|[^"])*)"/i);
+        let regexArray: RegExpExecArray | null;
+
         regexArray = regexScanId.exec(data);
-        
+
         try {
             if (regexArray) {
                 //m[2] is the scanID
                 console.log("Canceling scan with ID: " + regexArray[2])
-                const cxCommandOutput: CxCommandOutput = await wrapper.scanCancel(regexArray[2]);
-                taskLib.setResult(cxCommandOutput.exitCode == 0 ?
-                taskLib.TaskResult.Succeeded : taskLib.TaskResult.Failed, "");
-            }
-            else {
+                await wrapper.scanCancel(regexArray[2]);
+            } else {
                 console.log("Scan not created. Terminating job.")
             }
         } catch (err) {
             console.log("Error canceling scan: " + err + " " + Date.now().toString())
-            taskLib.setResult(taskLib.TaskResult.Failed, JSON.stringify(err));
         }
+        taskLib.setResult(taskLib.TaskResult.Succeeded, "");
     }
 }
-


### PR DESCRIPTION
### Description

The post job was trying to cancel the scan even if the pipeline was not cancelled. This PR fixes this behavior by only cancelling the scan if the pipeline was canceled. Also, the pipeline will not fail if the post job cancel fails.

### References

N/A

### Testing

N/A

### Checklist

- [x] I have added documentation for new/changed functionality in this PR (if applicable).
- [x] I have updated the CLI help for new/changed functionality in this PR (if applicable).
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used