### PR TITLE
Update wrapper to version 0.0.93 with CLI 2.1.14 (AST-43852)

### DIFF
--- a/cxAstScan/package-lock.json
+++ b/cxAstScan/package-lock.json
@@ -5,15 +5,15 @@
   "packages": {
     "": {
       "dependencies": {
-        "@checkmarxdev/ast-cli-javascript-wrapper": "0.0.90",
+        "@checkmarxdev/ast-cli-javascript-wrapper": "0.0.93",
         "azure-pipelines-task-lib": "4.10.1"
       }
     },
     "node_modules/@checkmarxdev/ast-cli-javascript-wrapper": {
       "name": "@CheckmarxDev/ast-cli-javascript-wrapper",
-      "version": "0.0.90",
-      "resolved": "https://npm.pkg.github.com/download/@CheckmarxDev/ast-cli-javascript-wrapper/0.0.90/e0aaad3d0ebfef69b024d3c3162696b464900ae3",
-      "integrity": "sha512-Ta+EtwHXljmNqPdx0XTd95aQd6HM161D4A1EjbCXUPUPtMtcVjHEvjXtIAUuvj2O9SX5oiEdCYaFR4vSQwHruA==",
+      "version": "0.0.93",
+      "resolved": "https://npm.pkg.github.com/download/@CheckmarxDev/ast-cli-javascript-wrapper/0.0.93/301f803e26a5fff3fed8cfa846b96e6426aa49c2",
+      "integrity": "sha512-LToQa5cYQqnCpXI6+E417BcmxSe3qhxqjjpPbLf43SLyBQaPht2gKdJxkKYU+kLs8A4+kA0NIIRqqr8CAMY3VA==",
       "dependencies": {
         "log4js": "^6.9.1"
       }
@@ -489,9 +489,9 @@
   },
   "dependencies": {
     "@checkmarxdev/ast-cli-javascript-wrapper": {
-      "version": "npm:@CheckmarxDev/ast-cli-javascript-wrapper@0.0.90",
-      "resolved": "https://npm.pkg.github.com/download/@CheckmarxDev/ast-cli-javascript-wrapper/0.0.90/e0aaad3d0ebfef69b024d3c3162696b464900ae3",
-      "integrity": "sha512-Ta+EtwHXljmNqPdx0XTd95aQd6HM161D4A1EjbCXUPUPtMtcVjHEvjXtIAUuvj2O9SX5oiEdCYaFR4vSQwHruA==",
+      "version": "npm:@CheckmarxDev/ast-cli-javascript-wrapper@0.0.93",
+      "resolved": "https://npm.pkg.github.com/download/@CheckmarxDev/ast-cli-javascript-wrapper/0.0.93/301f803e26a5fff3fed8cfa846b96e6426aa49c2",
+      "integrity": "sha512-LToQa5cYQqnCpXI6+E417BcmxSe3qhxqjjpPbLf43SLyBQaPht2gKdJxkKYU+kLs8A4+kA0NIIRqqr8CAMY3VA==",
       "requires": {
         "log4js": "^6.9.1"
       }

--- a/cxAstScan/package.json
+++ b/cxAstScan/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
     "azure-pipelines-task-lib": "4.10.1",
-    "@checkmarxdev/ast-cli-javascript-wrapper": "0.0.90"
+    "@checkmarxdev/ast-cli-javascript-wrapper": "0.0.93"
   }
 }


### PR DESCRIPTION
### Description

> Update wrapper with bug fixes


### References

> AST-43852 - SCA Snoozed and muted dependencies ignored in last version of Cx CLI

### Testing

> unit/integration

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR (if applicable).
- [ ] I have updated the CLI help for new/changed functionality in this PR (if applicable).
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used