### PR TITLE
Add new  CxOneCurrentScanId pipeline runtime variable (AST-113124)

### DIFF
--- a/cxAstScan/services/TaskRunner.ts
+++ b/cxAstScan/services/TaskRunner.ts
@@ -46,6 +46,7 @@ export class TaskRunner {
 
                 if (agentTempDirectory && scan && scan.id) {
                     taskLib.setVariable("CxOneScanId", scan.id);
+                    taskLib.setVariable("CxOneCurrentScanId", scan.id, false, false);
                     await this.generateResults(wrapper, agentTempDirectory, scan.id);
                 }
             }


### PR DESCRIPTION
### Description

> **CxOneCurrentScanId** is a runtime variable set for the current pipeline job. Will available to all subsequent tasks in the same job
### References

> [Include supporting link to GitHub Issue/PR number](https://checkmarx.atlassian.net/browse/AST-113124)

### Testing

> Add a Bash script step to the pipeline that echoes $(CxOneCurrentScanId) and verify that the value is printed correctly.

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR (if applicable).
- [ ] I have updated the CLI help for new/changed functionality in this PR (if applicable).
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used

<img width="1425" height="589" alt="image" src="https://github.com/user-attachments/assets/8d9a676d-22c5-4270-88f6-f56631dbd145" />

<img width="1278" height="573" alt="image" src="https://github.com/user-attachments/assets/c6283918-c022-412b-8554-1347f352c6df" />
