### PR TITLE
Fix serialize-javascript vulnerability (AST-145686)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3083,16 +3083,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -3215,27 +3205,6 @@
         "queue-microtask": "^1.2.2"
       }
     },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/semver": {
       "version": "7.7.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
@@ -3249,13 +3218,13 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+      "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/set-blocking": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "typescript": "^5.6.3"
   },
   "overrides": {
-     "codecov": {
+    "serialize-javascript": "^7.0.5",
+    "codecov": {
       "js-yaml": "4.1.1"
     },
     "@humanwhocodes/config-array": {


### PR DESCRIPTION
## Summary
- Adds npm override for `serialize-javascript` to `^7.0.5` in package.json
- Fixes CPU Exhaustion Denial of Service vulnerability (CVE-2026-34043) in mocha's transitive dependency
- Fixes Remote Code Execution vulnerability (GHSA-5c6j-r48x-rmvq) via RegExp.flags and Date.prototype.toISOString()
- Maintains mocha at stable version 10.7.0 with minimal changes

## Test Plan
- [x] npm install completes successfully
- [x] serialize-javascript overridden to 7.0.5
- [x] npm audit no longer flags serialize-javascript vulnerabilities
- [x] No regressions with mocha or its test runner

## Details
serialize-javascript 6.0.2 (currently used by mocha 10.7.0) is vulnerable to:
- **CVE-2026-34043**: CPU Exhaustion DoS via crafted array-like objects
- **GHSA-5c6j-r48x-rmvq**: RCE via RegExp.flags and Date.prototype.toISOString()

This override ensures security while keeping mocha at the stable version until a patched version is released.

🤖 Generated with [Claude Code](https://claude.com/claude-code)