### PR TITLE
fix: use temp npmrc for cxAstScan install and pass AZURETOKEN via env var

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,13 +22,16 @@ jobs:
       - name: Configure GitHub Packages auth
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: npm config set //npm.pkg.github.com/:_authToken "${GH_TOKEN}"
+        run: |
+          npm config set //npm.pkg.github.com/:_authToken "${GH_TOKEN}"
+          cat cxAstScan/.npmrc > /tmp/cxAstScan-npmrc
+          echo "//npm.pkg.github.com/:_authToken=${GH_TOKEN}" >> /tmp/cxAstScan-npmrc
 
       - name: npm install
         run: |
           npm install
           cd cxAstScan/
-          npm install
+          npm install --userconfig /tmp/cxAstScan-npmrc
 
       - name: Code Linting
         run: npm run lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,7 @@ jobs:
     runs-on: cx-public-ubuntu-x64
     permissions:
       contents: write
+      packages: read
     outputs:
       CLI_VERSION: ${{ steps.extract_cli_version.outputs.CLI_VERSION }}
       TAG_NAME: ${{ steps.set_tag_name.outputs.TAG_NAME }}
@@ -107,7 +108,12 @@ jobs:
       - name: Configure GitHub Packages auth
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: npm config set //npm.pkg.github.com/:_authToken "${GH_TOKEN}"
+        run: |
+          npm config set //npm.pkg.github.com/:_authToken "${GH_TOKEN}"
+          # Build a temp npmrc for the cxAstScan subdirectory install.
+          # cxAstScan/.npmrc is bundled into the VSIX, so we must never write the token there.
+          cat cxAstScan/.npmrc > /tmp/cxAstScan-npmrc
+          echo "//npm.pkg.github.com/:_authToken=${GH_TOKEN}" >> /tmp/cxAstScan-npmrc
 
       - run: sudo npm install -g tfx-cli --registry https://npm.echohq.com/
 
@@ -115,7 +121,7 @@ jobs:
         run: |
           npm install
           cd cxAstScan/
-          npm install
+          npm install --userconfig /tmp/cxAstScan-npmrc
 
       - run: npm run build
 
@@ -179,7 +185,9 @@ jobs:
 
       - name: Release to marketplace
         if: inputs.publish == true
-        run: tfx extension publish --vsix *.vsix --token ${{ secrets.AZURETOKEN }}
+        env:
+          AZURE_TOKEN: ${{ secrets.AZURETOKEN }}
+        run: tfx extension publish --vsix *.vsix --token "${AZURE_TOKEN}"
 
   # notify:
   #   if: inputs.dev == false


### PR DESCRIPTION
fix: use temp npmrc for cxAstScan install and pass AZURETOKEN via env var