### PR TITLE
Ast 157281 publish plugin version via cli

### DIFF
--- a/.github/pr-labeler.yml
+++ b/.github/pr-labeler.yml
@@ -1,4 +1,23 @@
-feature: ['feature/*', 'feat/*']
-bug: ['fix/*', 'bug/*']
-dependencies: dependabot/*
-cxone: dependabot/npm_and_yarn/cxAstScan/checkmarx/ast-cli-javascript-wrapper*
+feature:
+  - head-branch: ['^feature/', '^feat/']
+
+bug:
+  - head-branch: ['^bug/', '^fix/', '^hotfix/']
+
+chore:
+  - head-branch: ['^chore/', '^refactor/', '^cleanup/']
+
+documentation:
+  - head-branch: ['^docs/', '^doc
+
+ci/cd:
+  - head-branch: ['^ci/', '^cd/', '^pipeline/']
+
+dependencies:
+  - head-branch: ['^deps/', '^dep
+
+security:
+  - head-branch: ['^security/', '^sec/']
+
+AST:
+  - head-branch: '^AST-'

--- a/.github/workflows/ast-scan.yml
+++ b/.github/workflows/ast-scan.yml
@@ -8,6 +8,10 @@ on:
   schedule:
     - cron: '00 7 * * *' # Every day at 07:00
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false  # false for scheduled runs to avoid cancelling daily scans
+
 jobs:
   cx-scan:
     name: Checkmarx One Scan

--- a/.github/workflows/ast-scan.yml
+++ b/.github/workflows/ast-scan.yml
@@ -12,13 +12,20 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false  # false for scheduled runs to avoid cancelling daily scans
 
+permissions:
+  contents: read  # Minimum required for workflow execution
+
 jobs:
   cx-scan:
     name: Checkmarx One Scan
     runs-on: cx-public-ubuntu-x64
+    permissions:
+      contents: read  # Required to checkout repository for scanning
     steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          persist-credentials: false
       - name: Checkmarx One CLI Action
         uses: checkmarx/ast-github-action@03a90e7253dadd7e2fff55f5dfbce647b39040a1 # v.2.0.37
         with:

--- a/.github/workflows/auto-merge-pr.yml
+++ b/.github/workflows/auto-merge-pr.yml
@@ -6,13 +6,15 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  contents: write  # Required for auto-merging PRs
-  pull-requests: write  # Required to merge PRs
+  contents: none
 
 jobs:
   dependabot-merge:
     name: Auto-merge feature/update_js_wrapper PRs
     runs-on: cx-public-ubuntu-x64
+    permissions:
+      contents: write       # Required to push the auto-merge commit
+      pull-requests: write  # Required to merge PRs
     if: contains(github.head_ref, 'feature/update_js_wrapper')
     steps:
       - name: Enable auto-merge for Dependabot PRs

--- a/.github/workflows/auto-merge-pr.yml
+++ b/.github/workflows/auto-merge-pr.yml
@@ -6,7 +6,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  contents: none
+  contents: none  # Explicitly deny all content access at workflow level
 
 jobs:
   dependabot-merge:

--- a/.github/workflows/auto-merge-pr.yml
+++ b/.github/workflows/auto-merge-pr.yml
@@ -1,11 +1,17 @@
 name: Post-Check Actions
 on: [pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
-  contents: write
+  contents: write  # Required for auto-merging PRs
+  pull-requests: write  # Required to merge PRs
 
 jobs:
   dependabot-merge:
+    name: Auto-merge feature/update_js_wrapper PRs
     runs-on: cx-public-ubuntu-x64
     if: contains(github.head_ref, 'feature/update_js_wrapper')
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,17 +2,24 @@ name: AST Azure wrapper CI
 
 on: [pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
 jobs:
   integration-tests:
+    name: Integration Tests
     runs-on: cx-public-ubuntu-x64
     permissions:
       contents: read
-      packages: read
+      packages: read  # Required to pull @Checkmarx package from GitHub Packages
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Verify single lockfile
         run: |

--- a/.github/workflows/issue-automation.yml
+++ b/.github/workflows/issue-automation.yml
@@ -4,6 +4,10 @@ on:
   issues:
     types: [opened, closed]
 
+permissions:
+  contents: read  # Minimum required for workflow execution
+  issues: write   # Required to interact with issues
+
 jobs:
   notify_jira:
     if: github.event.action == 'opened'

--- a/.github/workflows/issue-automation.yml
+++ b/.github/workflows/issue-automation.yml
@@ -5,7 +5,7 @@ on:
     types: [opened, closed]
 
 permissions:
-  contents: none
+  contents: none  # Explicitly deny all content access at workflow level
 
 jobs:
   notify_jira:

--- a/.github/workflows/issue-automation.yml
+++ b/.github/workflows/issue-automation.yml
@@ -5,14 +5,15 @@ on:
     types: [opened, closed]
 
 permissions:
-  contents: read  # Minimum required for workflow execution
-  issues: write   # Required to interact with issues
+  contents: none
 
 jobs:
   notify_jira:
     if: github.event.action == 'opened'
     name: Notify Jira
-    uses: Checkmarx/plugins-release-workflow/.github/workflows/jira_notify.yml@main
+    permissions:
+      issues: write  # Required to interact with issues via reusable workflow
+    uses: Checkmarx/plugins-release-workflow/.github/workflows/jira_notify.yml@e03847305df9c065dbba91c7878355723d1d38f8
     with:
       title: ${{ github.event.issue.title }}
       body: ${{ github.event.issue.body }}
@@ -23,7 +24,9 @@ jobs:
   close_jira:
     if: github.event.action == 'closed'
     name: Close Jira
-    uses: Checkmarx/plugins-release-workflow/.github/workflows/jira_close.yml@main
+    permissions:
+      issues: write  # Required to interact with issues via reusable workflow
+    uses: Checkmarx/plugins-release-workflow/.github/workflows/jira_close.yml@e03847305df9c065dbba91c7878355723d1d38f8
     with:
       issue_number: ${{ github.event.issue.number }}
       repo: ${{ github.event.repository.full_name }}

--- a/.github/workflows/manual-tag.yml
+++ b/.github/workflows/manual-tag.yml
@@ -7,26 +7,35 @@ on:
         description: 'Next release tag'
         required: true
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
 
 jobs:
   tag-creation:
+    name: Create and Push Tag
     permissions:
-      contents: write  # for Git to git push
+      contents: write  # Required to push git tags
     runs-on: cx-public-ubuntu-x64
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          persist-credentials: false
       - name: Tag
+        env:
+          TAG: ${{ github.event.inputs.tag }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          echo ${{ github.event.inputs.tag }}
-          echo "NEXT_VERSION=${{ github.event.inputs.tag }}" >> $GITHUB_ENV
-          tag=${{ github.event.inputs.tag }}
-          message='${{ github.event.inputs.tag }}: PR #${{ github.event.pull_request.number }} ${{ github.event.pull_request.title }}'
+          echo "$TAG"
+          echo "NEXT_VERSION=$TAG" >> $GITHUB_ENV
+          message="$TAG: PR #$PR_NUMBER $PR_TITLE"
           git config user.name "${GITHUB_ACTOR}"
           git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
-          git tag -a "${tag}" -m "${message}"
-          git push origin "${tag}"
+          git tag -a "$TAG" -m "$message"
+          git push origin "$TAG"

--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -8,7 +8,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  contents: none
+  contents: none  # Explicitly deny all content access at workflow level
 
 jobs:
   add-assignee-and-reviewers:

--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -1,22 +1,26 @@
 name: PR Automation
 on:
-  pull_request_target:
+  pull_request:
     types: [ready_for_review, opened, reopened]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: none
-  issues: write
-  pull-requests: write
 
 jobs:
   add-assignee-and-reviewers:
+    name: Add Assignee and Reviewers
     runs-on: cx-public-ubuntu-x64
+    permissions:
+      pull-requests: write  # Required to add reviewers to PRs
     if: ${{ github.event.pull_request.user.type != 'Bot' }}
     steps:
       - name: Request reviewers
         env:
           GH_REPO: ${{ github.repository }}
-          GH_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN  }}
+          GH_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
           PRNUM: ${{ github.event.pull_request.number }}
-          PRAUTHOR: ${{ github.event.pull_request.user.login }}
-        run: gh pr edit $PRNUM --add-reviewer cx-plugins-releases
+        run: gh pr edit "$PRNUM" --add-reviewer cx-plugins-releases

--- a/.github/workflows/pr-label.yml
+++ b/.github/workflows/pr-label.yml
@@ -3,13 +3,19 @@ on:
   pull_request:
     types: [opened]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
+  pull-requests: write  # Required to apply labels to PRs
 
-# jobs:
-#   pr-labeler:
-#     runs-on: cx-public-ubuntu-x64
-#     steps:
-#       - uses: TimonVS/pr-labeler-action@f9c084306ce8b3f488a8f3ee1ccedc6da131d1af #v5
-#         env:
-#           GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+jobs:
+  pr-labeler:
+    name: Label PR
+    runs-on: cx-public-ubuntu-x64
+    steps:
+      - uses: TimonVS/pr-labeler-action@f9c084306ce8b3f488a8f3ee1ccedc6da131d1af #v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}

--- a/.github/workflows/pr-label.yml
+++ b/.github/workflows/pr-label.yml
@@ -8,7 +8,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  contents: none
+  contents: none  # Explicitly deny all content access at workflow level
 
 jobs:
   pr-labeler:

--- a/.github/workflows/pr-label.yml
+++ b/.github/workflows/pr-label.yml
@@ -8,13 +8,14 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  contents: read
-  pull-requests: write  # Required to apply labels to PRs
+  contents: none
 
 jobs:
   pr-labeler:
     name: Label PR
     runs-on: cx-public-ubuntu-x64
+    permissions:
+      pull-requests: write  # Required to apply labels to PRs
     steps:
       - uses: TimonVS/pr-labeler-action@f9c084306ce8b3f488a8f3ee1ccedc6da131d1af #v5
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Release Creation
+﻿name: Release Creation
 
 on:
   workflow_dispatch:
@@ -32,14 +32,16 @@ jobs:
   release:
     runs-on: cx-public-ubuntu-x64
     permissions:
-      contents: write
-      packages: read
+      contents: write  # Required to create tags and releases
+      packages: read   # Required to pull @Checkmarx package from GitHub Packages
     outputs:
       CLI_VERSION: ${{ steps.extract_cli_version.outputs.CLI_VERSION }}
       TAG_NAME: ${{ steps.set_tag_name.outputs.TAG_NAME }}
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Verify single lockfile
         run: |
@@ -54,11 +56,14 @@ jobs:
           fi
 
       - name: Set Extension and Publisher ID
+        env:
+          IS_DEV: ${{ inputs.dev }}
+          PUBLISHER_ID: ${{ inputs.publisherID }}
         run: |
-          if [ "${{ inputs.dev }}" == "true" ]; then
+          if [ "$IS_DEV" == "true" ]; then
             echo "EXTENSION_ID=checkmarx-ast-azure-plugin-dev" >> $GITHUB_ENV
-            if [ -n "${{ inputs.publisherID }}" ]; then
-              echo "PUBLISHER=${{ inputs.publisherID }}" >> $GITHUB_ENV
+            if [ -n "$PUBLISHER_ID" ]; then
+              echo "PUBLISHER=$PUBLISHER_ID" >> $GITHUB_ENV
             fi
           else
             echo "EXTENSION_ID=checkmarx-ast-azure-plugin" >> $GITHUB_ENV
@@ -68,15 +73,14 @@ jobs:
         id: set_tag_name
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INPUT_TAG: ${{ inputs.tag }}
         run: |
-          if [[ -z "${{ inputs.tag }}" ]]; then
-            # Fetch the latest GitHub release tag
+          if [[ -z "$INPUT_TAG" ]]; then
             LATEST_TAG=$(curl -sL \
               -H "Accept: application/vnd.github.v3+json" \
               -H "Authorization: token ${GH_TOKEN}" \
               "https://api.github.com/repos/${{ github.repository }}/releases/latest" | jq -r .tag_name)
 
-            # If no release is found, fallback to default
             if [[ "$LATEST_TAG" == "null" || -z "$LATEST_TAG" ]]; then
               echo "No release found, should provide a tag"
               exit 1
@@ -84,7 +88,6 @@ jobs:
 
             echo "Latest GitHub release tag: $LATEST_TAG"
 
-            # Extract numeric parts safely
             if [[ $LATEST_TAG =~ ^v?([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
               MAJOR="${BASH_REMATCH[1]}"
               MINOR="${BASH_REMATCH[2]}"
@@ -94,11 +97,10 @@ jobs:
               exit 1
             fi
 
-            # Bump patch version
             NEW_PATCH=$((PATCH + 1))
             NEW_VERSION="${MAJOR}.${MINOR}.${NEW_PATCH}"
           else
-            NEW_VERSION="${{ inputs.tag }}"
+            NEW_VERSION="$INPUT_TAG"
           fi
 
           echo "RELEASE_VERSION=$NEW_VERSION" >> $GITHUB_ENV
@@ -135,12 +137,10 @@ jobs:
       - name: Set major, minor, patch values
         run: |
           CLEAN_VERSION=$(echo "${{ env.RELEASE_VERSION }}" | sed 's/^v//')
-
           echo "CLEAN_VERSION=$CLEAN_VERSION" >> $GITHUB_ENV
           echo "MAJOR_VERSION=$(echo $CLEAN_VERSION | cut -d. -f1)" >> $GITHUB_ENV
           echo "MINOR_VERSION=$(echo $CLEAN_VERSION | cut -d. -f2)" >> $GITHUB_ENV
           echo "PATCH_VERSION=$(echo $CLEAN_VERSION | cut -d. -f3)" >> $GITHUB_ENV
-
 
       - name: New version
         run: |
@@ -152,8 +152,6 @@ jobs:
       - name: Extract CLI version
         id: extract_cli_version
         run: |
-          ls -la
-          pwd
           CLI_VERSION=$(cat ./cxAstScan/node_modules/@Checkmarx/ast-cli-javascript-wrapper-runtime-cli/checkmarx-ast-cli.version | grep -Eo '^[0-9]+\.[0-9]+\.[0-9]+')
           echo "CLI version being packed is $CLI_VERSION"
           echo "CLI_VERSION=$CLI_VERSION" >> $GITHUB_ENV
@@ -168,11 +166,14 @@ jobs:
           cat <<< $(jq ".version.Patch = ${{ env.PATCH_VERSION }}" ./cxAstScan/task.json) > ./cxAstScan/task.json
 
       - name: Set ID public and publisher fields if dev release
+        env:
+          IS_DEV: ${{ inputs.dev }}
+          PUBLISHER_ID: ${{ inputs.publisherID }}
         run: |
-          if [ "${{ inputs.dev }}" == "true" ]; then
+          if [ "$IS_DEV" == "true" ]; then
             cat <<< $(jq ".public = false" vss-extension.json) > vss-extension.json
             cat <<< $(jq ".id = \"${{ env.EXTENSION_ID }}\"" vss-extension.json) > vss-extension.json
-            cat <<< $(jq ".publisher = \"${{ inputs.publisherID }}\"" vss-extension.json) > vss-extension.json
+            cat <<< $(jq ".publisher = \"$PUBLISHER_ID\"" vss-extension.json) > vss-extension.json
           fi
 
       - name: Remove test folder

--- a/.github/workflows/update-js-runtime-wrapper.yml
+++ b/.github/workflows/update-js-runtime-wrapper.yml
@@ -8,19 +8,26 @@ on:
         required: false
         default: ""
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
 
 jobs:
   update-js-wrapper:
+    name: Update JS Runtime Wrapper Version
     runs-on: cx-public-ubuntu-x64
     permissions:
-      contents: write
-      pull-requests: write
+      contents: write       # Required to commit version bump changes
+      pull-requests: write  # Required to open a PR with the changes
 
     steps:
       - name: Checkout Repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Verify single lockfile
         run: |
@@ -36,11 +43,13 @@ jobs:
 
       - name: Determine Version
         id: get_version
+        env:
+          INPUT_VERSION: ${{ github.event.inputs.version }}
         run: |
-          if [[ -n "${{ github.event.inputs.version }}" ]]; then
-            VERSION="${{ github.event.inputs.version }}"
+          if [[ -n "$INPUT_VERSION" ]]; then
+            VERSION="$INPUT_VERSION"
           else
-            VERSION=$(curl -s "https://api.github.com/repos/Checkmarx/ast-cli-javascript-wrapper-runtime-cli/releases" | jq -r '[.[] | select(.prerelease == false) | .tag_name | select(test("^v?[0-9]+\\.[0-9]+\\.[0-9]+$")) | ltrimstr("v")] | sort_by(split(".") | map(tonumber)) | .[-1]')
+            VERSION=$(curl -s "https://api.github.com/repos/Checkmarx/ast-cli-javascript-wrapper-runtime-cli/releases" | jq -r '[.[] | select(.prerelease == false) | .tag_name | select(test("^v?[0-9]+\.[0-9]+\.[0-9]+$")) | ltrimstr("v")] | sort_by(split(".") | map(tonumber)) | .[-1]')
           fi
 
           # Remove leading 'v' if present
@@ -57,7 +66,7 @@ jobs:
 
       - name: Update package.json
         run: |
-          sed -i "s|\"@Checkmarx/ast-cli-javascript-wrapper-runtime-cli\": \"[0-9]*\\.[0-9]*\\.[0-9]*\"|\"@Checkmarx/ast-cli-javascript-wrapper-runtime-cli\": \"${VERSION}\"|" cxAstScan/package.json
+          sed -i "s|\"@Checkmarx/ast-cli-javascript-wrapper-runtime-cli\": \"[0-9]*\.[0-9]*\.[0-9]*\"|\"@Checkmarx/ast-cli-javascript-wrapper-runtime-cli\": \"${VERSION}\"|" cxAstScan/package.json
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:

--- a/cxAstScan/.npmrc
+++ b/cxAstScan/.npmrc
@@ -1,5 +1,8 @@
-Default registry for most packages
+# Default registry for most packages
 registry=https://npm.echohq.com/
 
 # GitHub Packages scope
 @Checkmarx:registry=https://npm.pkg.github.com/
+
+# GitHub Packages auth
+//npm.pkg.github.com/:_authToken=

--- a/cxAstScan/package-lock.json
+++ b/cxAstScan/package-lock.json
@@ -5,14 +5,14 @@
   "packages": {
     "": {
       "dependencies": {
-        "@Checkmarx/ast-cli-javascript-wrapper-runtime-cli": "1.0.39",
+        "@Checkmarx/ast-cli-javascript-wrapper-runtime-cli": "file:../../../../AppData/Local/Temp/Checkmarx-ast-cli-javascript-wrapper-runtime-cli-1.0.40.tgz",
         "azure-pipelines-task-lib": "4.17.3"
       }
     },
     "node_modules/@Checkmarx/ast-cli-javascript-wrapper-runtime-cli": {
-      "version": "1.0.39",
-      "resolved": "https://npm.pkg.github.com/download/@Checkmarx/ast-cli-javascript-wrapper-runtime-cli/1.0.39/1f928d7b4fced943433df29d2741114679d6ffa9",
-      "integrity": "sha512-1pyOjakTtfIGsfk8run18/fEWNoKiJYmXl14yWYb7/rN53SyI5SNsjUqbZh5xZ7l3uPsTL8FDTjzPWkrsQbYHg==",
+      "version": "1.0.40",
+      "resolved": "file:../../../../AppData/Local/Temp/Checkmarx-ast-cli-javascript-wrapper-runtime-cli-1.0.40.tgz",
+      "integrity": "sha512-urn98ls0loqm823oe1YMZs5LK2KiSvH5ECvKrFl0dBev++7bM5x29al1cY5f5ON3j4sTPq4I5j2qWKgo8itXxg==",
       "license": "ISC",
       "dependencies": {
         "async-mutex": "^0.5.0",
@@ -20,13 +20,13 @@
         "https-proxy-agent": "^7.0.6",
         "log4js": "^6.9.1",
         "node-fetch": "^3.3.2",
-        "tar": "^7.5.11",
+        "tar": "7.5.21",
         "unzipper": "^0.12.3"
       }
     },
     "node_modules/@isaacs/fs-minipass": {
       "version": "4.0.1",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
       "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
       "license": "ISC",
       "dependencies": {
@@ -38,7 +38,7 @@
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
       "license": "MIT",
       "dependencies": {
@@ -51,7 +51,7 @@
     },
     "node_modules/@nodelib/fs.stat": {
       "version": "2.0.5",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
       "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
       "license": "MIT",
       "engines": {
@@ -60,7 +60,7 @@
     },
     "node_modules/@nodelib/fs.walk": {
       "version": "1.2.8",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
       "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
       "license": "MIT",
       "dependencies": {
@@ -73,20 +73,20 @@
     },
     "node_modules/@types/semver": {
       "version": "5.5.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/@types/semver/-/semver-5.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-5.5.0.tgz",
       "integrity": "sha512-41qEJgBH/TWgo5NFSvBCJ1qkoi3Q6ONSF2avrHq1LVEZfYpdHmj0y9SuTK+u9ZhG1sYQKBL1AWXKyLWP4RaUoQ==",
       "license": "MIT"
     },
     "node_modules/@types/uuid": {
       "version": "3.4.13",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/@types/uuid/-/uuid-3.4.13.tgz",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-3.4.13.tgz",
       "integrity": "sha512-pAeZeUbLE4Z9Vi9wsWV2bYPTweEHeJJy0G4pEjOA/FSvy1Ad5U5Km8iDV6TKre1mjBiVNfAdVHKruP8bAh4Q5A==",
       "license": "MIT"
     },
     "node_modules/adm-zip": {
-      "version": "0.5.17",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/adm-zip/-/adm-zip-0.5.17.tgz",
-      "integrity": "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==",
+      "version": "0.5.18",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.18.tgz",
+      "integrity": "sha512-ufJnssQGbxzLNS1Ho9bCtX4rQKCCvoVuDLHoJyc3F9dOGDB4BkWs2Ci0kv53lqocAEQ/Cbi+I2XCsNYGqVYqng==",
       "license": "MIT",
       "engines": {
         "node": ">=12.0"
@@ -94,7 +94,7 @@
     },
     "node_modules/agent-base": {
       "version": "7.1.4",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/agent-base/-/agent-base-7.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
       "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
       "license": "MIT",
       "engines": {
@@ -103,7 +103,7 @@
     },
     "node_modules/async-mutex": {
       "version": "0.5.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/async-mutex/-/async-mutex-0.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.5.0.tgz",
       "integrity": "sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==",
       "license": "MIT",
       "dependencies": {
@@ -112,7 +112,7 @@
     },
     "node_modules/azure-pipelines-task-lib": {
       "version": "4.17.3",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/azure-pipelines-task-lib/-/azure-pipelines-task-lib-4.17.3.tgz",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-4.17.3.tgz",
       "integrity": "sha512-UxfH5pk3uOHTi9TtLtdDyugQVkFES5A836ZEePjcs3jYyxm3EJ6IlFYq6gbfd6mNBhrM9fxG2u/MFYIJ+Z0cxQ==",
       "license": "MIT",
       "dependencies": {
@@ -126,38 +126,37 @@
       }
     },
     "node_modules/azure-pipelines-tool-lib": {
-      "version": "2.0.12",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/azure-pipelines-tool-lib/-/azure-pipelines-tool-lib-2.0.12.tgz",
-      "integrity": "sha512-PcqNdHQR7HyXAcX/gbQfounoTKM0DvBhWcwxC6z5BizDYRqJPXhG4D1OVB+QoffpI+1O7+eUYiXg97ujkbNqOQ==",
+      "version": "2.279.0",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-tool-lib/-/azure-pipelines-tool-lib-2.279.0.tgz",
+      "integrity": "sha512-aGvBNstAoO/YR9HbAOndKIfEt2udaaSuIAcmrgYcSs2/vVEMEINio2+S57ET+wqz3XNDZkKr/TcCPU8WUYOHXQ==",
       "license": "MIT",
       "dependencies": {
         "@types/semver": "^5.3.0",
         "@types/uuid": "^3.4.5",
-        "azure-pipelines-task-lib": "^5.2.7",
+        "azure-pipelines-task-lib": "^5.279.0",
         "semver": "^5.7.0",
         "semver-compare": "^1.0.0",
-        "typed-rest-client": "^1.8.6",
+        "typed-rest-client": "^3.1.0",
         "uuid": "^3.3.2"
       }
     },
     "node_modules/azure-pipelines-tool-lib/node_modules/azure-pipelines-task-lib": {
-      "version": "5.2.11",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.2.11.tgz",
-      "integrity": "sha512-VaVvVaPe0ysvxGE10QysbEHuxL480kVDQvKjGd2gtO1eRY4/SkQKfAZrP6lLUAAgYMGk6eifl0I3kaRPzWQZ8g==",
+      "version": "5.279.0",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.279.0.tgz",
+      "integrity": "sha512-abej/e5UxEr23vGH6cDlWsCq7fGS6Zna95JEey5bSsyYQZZyqieDIoVrBNe1tCTwCSzFEW+F7FcVUAqGpM/wvg==",
       "license": "MIT",
       "dependencies": {
-        "adm-zip": "^0.5.10",
+        "adm-zip": "^0.6.0",
         "minimatch": "^3.1.5",
         "nodejs-file-downloader": "^4.11.1",
         "q": "^1.5.1",
         "semver": "^5.7.2",
-        "shelljs": "^0.10.0",
-        "uuid": "^3.0.1"
+        "shelljs": "^0.10.0"
       }
     },
     "node_modules/azure-pipelines-tool-lib/node_modules/shelljs": {
       "version": "0.10.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/shelljs/-/shelljs-0.10.0.tgz",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.10.0.tgz",
       "integrity": "sha512-Jex+xw5Mg2qMZL3qnzXIfaxEtBaC4n7xifqaqtrZDdlheR70OGkydrPJWT0V1cA1k3nanC86x9FwAmQl6w3Klw==",
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -170,29 +169,28 @@
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/balanced-match/-/balanced-match-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "license": "MIT"
     },
     "node_modules/bluebird": {
       "version": "3.7.2",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/bluebird/-/bluebird-3.7.2.tgz",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
       "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
+        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/braces": {
       "version": "3.0.3",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/braces/-/braces-3.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "license": "MIT",
       "dependencies": {
@@ -204,7 +202,7 @@
     },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
       "license": "MIT",
       "dependencies": {
@@ -217,7 +215,7 @@
     },
     "node_modules/call-bound": {
       "version": "1.0.4",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/call-bound/-/call-bound-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
       "license": "MIT",
       "dependencies": {
@@ -233,28 +231,22 @@
     },
     "node_modules/chownr": {
       "version": "3.0.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/chownr/-/chownr-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
       "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
       }
     },
-    "node_modules/concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "license": "MIT"
-    },
     "node_modules/core-util-is": {
       "version": "1.0.3",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/core-util-is/-/core-util-is-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "license": "MIT",
       "dependencies": {
@@ -268,7 +260,7 @@
     },
     "node_modules/data-uri-to-buffer": {
       "version": "4.0.1",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
       "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
       "license": "MIT",
       "engines": {
@@ -277,7 +269,7 @@
     },
     "node_modules/date-format": {
       "version": "4.0.14",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/date-format/-/date-format-4.0.14.tgz",
+      "resolved": "https://registry.npmjs.org/date-format/-/date-format-4.0.14.tgz",
       "integrity": "sha512-39BOQLs9ZjKh0/patS9nrT8wc3ioX3/eA/zgbKNopnF2wCqJEoxywwwElATYvRsXdnOxA/OQeQoFZ3rFjVajhg==",
       "license": "MIT",
       "engines": {
@@ -286,7 +278,7 @@
     },
     "node_modules/debug": {
       "version": "4.4.3",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/debug/-/debug-4.4.3.tgz",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "license": "MIT",
       "dependencies": {
@@ -301,9 +293,19 @@
         }
       }
     },
+    "node_modules/des.js": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.1.0.tgz",
+      "integrity": "sha512-r17GxjhUCjSRy8aiJpr8/UadFIzMzJGexI3Nmz4ADi9LYSFx4gTBp80+NaX/YsXWWLhpZ7v/v/ubEc/bCNfKwg==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
       "license": "MIT",
       "dependencies": {
@@ -317,7 +319,7 @@
     },
     "node_modules/duplexer2": {
       "version": "0.1.4",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/duplexer2/-/duplexer2-0.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
       "integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -326,7 +328,7 @@
     },
     "node_modules/es-define-property": {
       "version": "1.0.1",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/es-define-property/-/es-define-property-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
       "license": "MIT",
       "engines": {
@@ -335,7 +337,7 @@
     },
     "node_modules/es-errors": {
       "version": "1.3.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/es-errors/-/es-errors-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
       "license": "MIT",
       "engines": {
@@ -344,7 +346,7 @@
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.2",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
       "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "license": "MIT",
       "dependencies": {
@@ -356,7 +358,7 @@
     },
     "node_modules/execa": {
       "version": "5.1.1",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/execa/-/execa-5.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
       "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
       "license": "MIT",
       "dependencies": {
@@ -379,7 +381,7 @@
     },
     "node_modules/fast-glob": {
       "version": "3.3.3",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/fast-glob/-/fast-glob-3.3.3.tgz",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
       "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
       "license": "MIT",
       "dependencies": {
@@ -395,7 +397,7 @@
     },
     "node_modules/fastq": {
       "version": "1.20.1",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/fastq/-/fastq-1.20.1.tgz",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
       "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
       "license": "ISC",
       "dependencies": {
@@ -404,7 +406,7 @@
     },
     "node_modules/fetch-blob": {
       "version": "3.2.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
       "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
       "funding": [
         {
@@ -427,7 +429,7 @@
     },
     "node_modules/fill-range": {
       "version": "7.1.1",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/fill-range/-/fill-range-7.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "license": "MIT",
       "dependencies": {
@@ -438,14 +440,14 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.4.2",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/flatted/-/flatted-3.4.2.tgz",
-      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.4.tgz",
+      "integrity": "sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q==",
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
       "version": "1.16.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
       "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
@@ -465,7 +467,7 @@
     },
     "node_modules/formdata-polyfill": {
       "version": "4.0.10",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
       "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
       "license": "MIT",
       "dependencies": {
@@ -477,7 +479,7 @@
     },
     "node_modules/fs-extra": {
       "version": "8.1.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/fs-extra/-/fs-extra-8.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
       "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
       "license": "MIT",
       "dependencies": {
@@ -491,13 +493,13 @@
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "license": "ISC"
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/function-bind/-/function-bind-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
       "license": "MIT",
       "funding": {
@@ -506,7 +508,7 @@
     },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
       "license": "MIT",
       "dependencies": {
@@ -530,7 +532,7 @@
     },
     "node_modules/get-proto": {
       "version": "1.0.1",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/get-proto/-/get-proto-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
       "license": "MIT",
       "dependencies": {
@@ -543,7 +545,7 @@
     },
     "node_modules/get-stream": {
       "version": "6.0.1",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/get-stream/-/get-stream-6.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
       "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
       "license": "MIT",
       "engines": {
@@ -555,7 +557,7 @@
     },
     "node_modules/glob": {
       "version": "7.2.3",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/glob/-/glob-7.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
       "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "license": "ISC",
@@ -576,7 +578,7 @@
     },
     "node_modules/glob-parent": {
       "version": "5.1.2",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/glob-parent/-/glob-parent-5.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "license": "ISC",
       "dependencies": {
@@ -588,7 +590,7 @@
     },
     "node_modules/gopd": {
       "version": "1.2.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/gopd/-/gopd-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
       "license": "MIT",
       "engines": {
@@ -600,13 +602,13 @@
     },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "license": "ISC"
     },
     "node_modules/has-symbols": {
       "version": "1.1.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/has-symbols/-/has-symbols-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "license": "MIT",
       "engines": {
@@ -618,7 +620,7 @@
     },
     "node_modules/hasown": {
       "version": "2.0.4",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/hasown/-/hasown-2.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
       "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
@@ -630,7 +632,7 @@
     },
     "node_modules/https-proxy-agent": {
       "version": "7.0.6",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
       "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
       "license": "MIT",
       "dependencies": {
@@ -643,7 +645,7 @@
     },
     "node_modules/human-signals": {
       "version": "2.1.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/human-signals/-/human-signals-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
       "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
       "license": "Apache-2.0",
       "engines": {
@@ -652,7 +654,7 @@
     },
     "node_modules/inflight": {
       "version": "1.0.6",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/inflight/-/inflight-1.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
       "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
       "license": "ISC",
@@ -663,13 +665,13 @@
     },
     "node_modules/inherits": {
       "version": "2.0.4",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/inherits/-/inherits-2.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
     "node_modules/interpret": {
       "version": "1.4.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/interpret/-/interpret-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
       "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
       "license": "MIT",
       "engines": {
@@ -678,7 +680,7 @@
     },
     "node_modules/is-core-module": {
       "version": "2.16.2",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/is-core-module/-/is-core-module-2.16.2.tgz",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
       "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
       "license": "MIT",
       "dependencies": {
@@ -693,7 +695,7 @@
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/is-extglob/-/is-extglob-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
       "license": "MIT",
       "engines": {
@@ -702,7 +704,7 @@
     },
     "node_modules/is-glob": {
       "version": "4.0.3",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/is-glob/-/is-glob-4.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
       "license": "MIT",
       "dependencies": {
@@ -714,7 +716,7 @@
     },
     "node_modules/is-number": {
       "version": "7.0.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/is-number/-/is-number-7.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "license": "MIT",
       "engines": {
@@ -723,7 +725,7 @@
     },
     "node_modules/is-stream": {
       "version": "2.0.1",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/is-stream/-/is-stream-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
       "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
       "license": "MIT",
       "engines": {
@@ -735,19 +737,25 @@
     },
     "node_modules/isarray": {
       "version": "1.0.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/isarray/-/isarray-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
       "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/isexe/-/isexe-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
     },
+    "node_modules/js-md4": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/js-md4/-/js-md4-0.3.2.tgz",
+      "integrity": "sha512-/GDnfQYsltsjRswQhN9fhv3EMw2sCpUdrdxyWDOUK7eyD++r3gRhzgiQgc/x4MAv2i1iuQ4lxO5mvqM3vj4bwA==",
+      "license": "MIT"
+    },
     "node_modules/jsonfile": {
       "version": "4.0.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/jsonfile/-/jsonfile-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
       "license": "MIT",
       "optionalDependencies": {
@@ -756,7 +764,7 @@
     },
     "node_modules/log4js": {
       "version": "6.9.1",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/log4js/-/log4js-6.9.1.tgz",
+      "resolved": "https://registry.npmjs.org/log4js/-/log4js-6.9.1.tgz",
       "integrity": "sha512-1somDdy9sChrr9/f4UlzhdaGfDR2c/SaD2a4T7qEkG4jTS57/B3qmnjLYePwQ8cqWnUHZI0iAKxMBpCZICiZ2g==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -772,7 +780,7 @@
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
       "license": "MIT",
       "engines": {
@@ -781,13 +789,13 @@
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/merge-stream/-/merge-stream-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
       "license": "MIT"
     },
     "node_modules/merge2": {
       "version": "1.4.1",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/merge2/-/merge2-1.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
       "license": "MIT",
       "engines": {
@@ -796,7 +804,7 @@
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/micromatch/-/micromatch-4.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "license": "MIT",
       "dependencies": {
@@ -809,7 +817,7 @@
     },
     "node_modules/mime-db": {
       "version": "1.52.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/mime-db/-/mime-db-1.52.0.tgz",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
       "license": "MIT",
       "engines": {
@@ -818,7 +826,7 @@
     },
     "node_modules/mime-types": {
       "version": "2.1.35",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/mime-types/-/mime-types-2.1.35.tgz",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
       "license": "MIT",
       "dependencies": {
@@ -830,16 +838,22 @@
     },
     "node_modules/mimic-fn": {
       "version": "2.1.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
       "license": "MIT",
       "engines": {
         "node": ">=6"
       }
     },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "license": "ISC"
+    },
     "node_modules/minimatch": {
       "version": "3.1.4",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/minimatch/-/minimatch-3.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.4.tgz",
       "integrity": "sha512-twmL+S8+7yIsE9wsqgzU3E8/LumN3M3QELrBZ20OdmQ9jB2JvW5oZtBEmft84k/Gs5CG9mqtWc6Y9vW+JEzGxw==",
       "license": "ISC",
       "dependencies": {
@@ -851,7 +865,7 @@
     },
     "node_modules/minipass": {
       "version": "7.1.3",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/minipass/-/minipass-7.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
       "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -860,7 +874,7 @@
     },
     "node_modules/minizlib": {
       "version": "3.1.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/minizlib/-/minizlib-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
       "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
       "license": "MIT",
       "dependencies": {
@@ -872,13 +886,13 @@
     },
     "node_modules/ms": {
       "version": "2.1.3",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/ms/-/ms-2.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
     "node_modules/node-domexception": {
       "version": "1.0.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/node-domexception/-/node-domexception-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
       "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
       "deprecated": "Use your platform's native DOMException instead",
       "funding": [
@@ -898,7 +912,7 @@
     },
     "node_modules/node-fetch": {
       "version": "3.3.2",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/node-fetch/-/node-fetch-3.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
       "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
       "license": "MIT",
       "dependencies": {
@@ -916,13 +930,13 @@
     },
     "node_modules/node-int64": {
       "version": "0.4.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/node-int64/-/node-int64-0.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
       "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
       "license": "MIT"
     },
     "node_modules/nodejs-file-downloader": {
       "version": "4.13.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/nodejs-file-downloader/-/nodejs-file-downloader-4.13.0.tgz",
+      "resolved": "https://registry.npmjs.org/nodejs-file-downloader/-/nodejs-file-downloader-4.13.0.tgz",
       "integrity": "sha512-nI2fKnmJWWFZF6SgMPe1iBodKhfpztLKJTtCtNYGhm/9QXmWa/Pk9Sv00qHgzEvNLe1x7hjGDRor7gcm/ChaIQ==",
       "license": "ISC",
       "dependencies": {
@@ -934,7 +948,7 @@
     },
     "node_modules/nodejs-file-downloader/node_modules/agent-base": {
       "version": "6.0.2",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/agent-base/-/agent-base-6.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
       "license": "MIT",
       "dependencies": {
@@ -946,7 +960,7 @@
     },
     "node_modules/nodejs-file-downloader/node_modules/https-proxy-agent": {
       "version": "5.0.1",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
       "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
       "license": "MIT",
       "dependencies": {
@@ -959,7 +973,7 @@
     },
     "node_modules/npm-run-path": {
       "version": "4.0.1",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
       "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
       "license": "MIT",
       "dependencies": {
@@ -971,7 +985,7 @@
     },
     "node_modules/object-inspect": {
       "version": "1.13.4",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/object-inspect/-/object-inspect-1.13.4.tgz",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
       "license": "MIT",
       "engines": {
@@ -983,7 +997,7 @@
     },
     "node_modules/once": {
       "version": "1.4.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/once/-/once-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "license": "ISC",
       "dependencies": {
@@ -992,7 +1006,7 @@
     },
     "node_modules/onetime": {
       "version": "5.1.2",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/onetime/-/onetime-5.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
       "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
       "license": "MIT",
       "dependencies": {
@@ -1007,7 +1021,7 @@
     },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
       "license": "MIT",
       "engines": {
@@ -1016,7 +1030,7 @@
     },
     "node_modules/path-key": {
       "version": "3.1.1",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/path-key/-/path-key-3.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "license": "MIT",
       "engines": {
@@ -1025,13 +1039,13 @@
     },
     "node_modules/path-parse": {
       "version": "1.0.7",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/path-parse/-/path-parse-1.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "license": "MIT"
     },
     "node_modules/picomatch": {
       "version": "2.3.2",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/picomatch/-/picomatch-2.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
       "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "license": "MIT",
       "engines": {
@@ -1043,13 +1057,13 @@
     },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "license": "MIT"
     },
     "node_modules/q": {
       "version": "1.5.1",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/q/-/q-1.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
       "integrity": "sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw==",
       "deprecated": "You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.\n\n(For a CapTP with native promises, see @endo/eventual-send and @endo/captp)",
       "license": "MIT",
@@ -1059,12 +1073,13 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.2",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/qs/-/qs-6.15.2.tgz",
-      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -1075,7 +1090,7 @@
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
       "funding": [
         {
@@ -1095,7 +1110,7 @@
     },
     "node_modules/readable-stream": {
       "version": "2.3.8",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/readable-stream/-/readable-stream-2.3.8.tgz",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
       "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
       "license": "MIT",
       "dependencies": {
@@ -1110,7 +1125,7 @@
     },
     "node_modules/rechoir": {
       "version": "0.6.2",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/rechoir/-/rechoir-0.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
       "integrity": "sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==",
       "dependencies": {
         "resolve": "^1.1.6"
@@ -1121,7 +1136,7 @@
     },
     "node_modules/resolve": {
       "version": "1.22.12",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/resolve/-/resolve-1.22.12.tgz",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
       "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
       "license": "MIT",
       "dependencies": {
@@ -1142,7 +1157,7 @@
     },
     "node_modules/reusify": {
       "version": "1.1.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/reusify/-/reusify-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
       "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
       "license": "MIT",
       "engines": {
@@ -1152,13 +1167,13 @@
     },
     "node_modules/rfdc": {
       "version": "1.4.1",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/rfdc/-/rfdc-1.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
       "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
       "license": "MIT"
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/run-parallel/-/run-parallel-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
       "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
       "funding": [
         {
@@ -1181,13 +1196,13 @@
     },
     "node_modules/safe-buffer": {
       "version": "5.1.2",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "license": "MIT"
     },
     "node_modules/sanitize-filename": {
       "version": "1.6.4",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/sanitize-filename/-/sanitize-filename-1.6.4.tgz",
+      "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.4.tgz",
       "integrity": "sha512-9ZyI08PsvdQl2r/bBIGubpVdR3RR9sY6RDiWFPreA21C/EFlQhmgo20UZlNjZMMZNubusLhAQozkA0Od5J21Eg==",
       "license": "WTFPL OR ISC",
       "dependencies": {
@@ -1195,9 +1210,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.8.4",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/semver/-/semver-7.8.4.tgz",
-      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -1208,13 +1223,13 @@
     },
     "node_modules/semver-compare": {
       "version": "1.0.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/semver-compare/-/semver-compare-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
       "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
       "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/shebang-command/-/shebang-command-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
       "license": "MIT",
       "dependencies": {
@@ -1226,7 +1241,7 @@
     },
     "node_modules/shebang-regex": {
       "version": "3.0.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "license": "MIT",
       "engines": {
@@ -1235,7 +1250,7 @@
     },
     "node_modules/shelljs": {
       "version": "0.8.5",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/shelljs/-/shelljs-0.8.5.tgz",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
       "integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -1252,7 +1267,7 @@
     },
     "node_modules/side-channel": {
       "version": "1.1.1",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/side-channel/-/side-channel-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
       "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "license": "MIT",
       "dependencies": {
@@ -1271,7 +1286,7 @@
     },
     "node_modules/side-channel-list": {
       "version": "1.0.1",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
       "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "license": "MIT",
       "dependencies": {
@@ -1287,7 +1302,7 @@
     },
     "node_modules/side-channel-map": {
       "version": "1.0.1",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
       "license": "MIT",
       "dependencies": {
@@ -1305,7 +1320,7 @@
     },
     "node_modules/side-channel-weakmap": {
       "version": "1.0.2",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
       "license": "MIT",
       "dependencies": {
@@ -1324,13 +1339,13 @@
     },
     "node_modules/signal-exit": {
       "version": "3.0.7",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/signal-exit/-/signal-exit-3.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "license": "ISC"
     },
     "node_modules/streamroller": {
       "version": "3.1.5",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/streamroller/-/streamroller-3.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/streamroller/-/streamroller-3.1.5.tgz",
       "integrity": "sha512-KFxaM7XT+irxvdqSP1LGLgNWbYN7ay5owZ3r/8t77p+EtSUAfUgtl7be3xtqtOmGUl9K9YPO2ca8133RlTjvKw==",
       "license": "MIT",
       "dependencies": {
@@ -1344,7 +1359,7 @@
     },
     "node_modules/string_decoder": {
       "version": "1.1.1",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/string_decoder/-/string_decoder-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "license": "MIT",
       "dependencies": {
@@ -1353,7 +1368,7 @@
     },
     "node_modules/strip-final-newline": {
       "version": "2.0.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
       "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
       "license": "MIT",
       "engines": {
@@ -1362,7 +1377,7 @@
     },
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
       "license": "MIT",
       "engines": {
@@ -1373,9 +1388,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.16",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/tar/-/tar-7.5.16.tgz",
-      "integrity": "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==",
+      "version": "7.5.21",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.21.tgz",
+      "integrity": "sha512-XdhtCvlMywwxpCW8YEq3lOXBJpUPTR2OHHcwLPO3HwsJqOHa2Ok/oJ7ruGzp+JrKoRPVCzJwAdEjqLW/vNRPHA==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
@@ -1390,7 +1405,7 @@
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
       "license": "MIT",
       "dependencies": {
@@ -1402,7 +1417,7 @@
     },
     "node_modules/truncate-utf8-bytes": {
       "version": "1.0.2",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
       "integrity": "sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ==",
       "license": "WTFPL",
       "dependencies": {
@@ -1411,13 +1426,13 @@
     },
     "node_modules/tslib": {
       "version": "2.8.1",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/tslib/-/tslib-2.8.1.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
     "node_modules/tunnel": {
       "version": "0.0.6",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/tunnel/-/tunnel-0.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
       "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
       "license": "MIT",
       "engines": {
@@ -1425,25 +1440,30 @@
       }
     },
     "node_modules/typed-rest-client": {
-      "version": "1.8.11",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/typed-rest-client/-/typed-rest-client-1.8.11.tgz",
-      "integrity": "sha512-5UvfMpd1oelmUPRbbaVnq+rHP7ng2cE4qoQkQeAqxRL6PklkxsM0g32/HL0yfvruK6ojQ5x8EE+HF4YV6DtuCA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-3.1.0.tgz",
+      "integrity": "sha512-8fMeur8aKaJw8WsqYUZD4CsUfpMFH3zWlRQigM3KWs406KGjqPMdTBn7RfIpMvPjZ1bH+S8QwG+FK/VY/8ndKg==",
       "license": "MIT",
       "dependencies": {
-        "qs": "^6.9.1",
+        "des.js": "^1.1.0",
+        "js-md4": "^0.3.2",
+        "qs": "6.15.3",
         "tunnel": "0.0.6",
-        "underscore": "^1.12.1"
+        "underscore": "^1.13.8"
+      },
+      "engines": {
+        "node": ">= 20.0.0"
       }
     },
     "node_modules/underscore": {
       "version": "1.13.8",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/underscore/-/underscore-1.13.8.tgz",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
       "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
       "license": "MIT"
     },
     "node_modules/universalify": {
       "version": "0.1.2",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/universalify/-/universalify-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
       "license": "MIT",
       "engines": {
@@ -1451,22 +1471,22 @@
       }
     },
     "node_modules/unzipper": {
-      "version": "0.12.3",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/unzipper/-/unzipper-0.12.3.tgz",
-      "integrity": "sha512-PZ8hTS+AqcGxsaQntl3IRBw65QrBI6lxzqDEL7IAo/XCEqRTKGfOX56Vea5TH9SZczRVxuzk1re04z/YjuYCJA==",
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.12.5.tgz",
+      "integrity": "sha512-tXYOi9R57Uj/2Z25SOs5RRSzq886MBQj2gY8dPL+xl/kv6s6SvByoKfAtvfVeEuhntWDgjd2o9p2lb4TVPAz0A==",
       "license": "MIT",
       "dependencies": {
         "bluebird": "~3.7.2",
         "duplexer2": "~0.1.4",
-        "fs-extra": "^11.2.0",
+        "fs-extra": "11.3.1",
         "graceful-fs": "^4.2.2",
         "node-int64": "^0.4.0"
       }
     },
     "node_modules/unzipper/node_modules/fs-extra": {
-      "version": "11.3.5",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/fs-extra/-/fs-extra-11.3.5.tgz",
-      "integrity": "sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==",
+      "version": "11.3.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.1.tgz",
+      "integrity": "sha512-eXvGGwZ5CL17ZSwHWd3bbgk7UUpF6IFHtP57NYYakPvHOs8GDgDe5KJI36jIJzDkJ6eJjuzRA8eBQb6SkKue0g==",
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -1479,7 +1499,7 @@
     },
     "node_modules/unzipper/node_modules/jsonfile": {
       "version": "6.2.1",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/jsonfile/-/jsonfile-6.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
       "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
       "license": "MIT",
       "dependencies": {
@@ -1491,7 +1511,7 @@
     },
     "node_modules/unzipper/node_modules/universalify": {
       "version": "2.0.1",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/universalify/-/universalify-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
       "license": "MIT",
       "engines": {
@@ -1500,19 +1520,19 @@
     },
     "node_modules/utf8-byte-length": {
       "version": "1.0.5",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/utf8-byte-length/-/utf8-byte-length-1.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.5.tgz",
       "integrity": "sha512-Xn0w3MtiQ6zoz2vFyUVruaCL53O/DwUvkEeOvj+uulMm0BkUGYWmBYVyElqZaSLhY6ZD0ulfU3aBra2aVT4xfA==",
       "license": "(WTFPL OR MIT)"
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
     },
     "node_modules/uuid": {
       "version": "3.4.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/uuid/-/uuid-3.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
       "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
       "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
       "license": "MIT",
@@ -1522,7 +1542,7 @@
     },
     "node_modules/web-streams-polyfill": {
       "version": "3.3.3",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
       "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
       "license": "MIT",
       "engines": {
@@ -1531,7 +1551,7 @@
     },
     "node_modules/which": {
       "version": "2.0.2",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/which/-/which-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
       "license": "ISC",
       "dependencies": {
@@ -1546,13 +1566,13 @@
     },
     "node_modules/wrappy": {
       "version": "1.0.2",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/wrappy/-/wrappy-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
     },
     "node_modules/yallist": {
       "version": "5.0.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/yallist/-/yallist-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
       "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
       "license": "BlueOak-1.0.0",
       "engines": {

--- a/cxAstScan/package-lock.json
+++ b/cxAstScan/package-lock.json
@@ -5,14 +5,14 @@
   "packages": {
     "": {
       "dependencies": {
-        "@Checkmarx/ast-cli-javascript-wrapper-runtime-cli": "1.0.37",
+        "@Checkmarx/ast-cli-javascript-wrapper-runtime-cli": "1.0.39",
         "azure-pipelines-task-lib": "4.17.3"
       }
     },
     "node_modules/@Checkmarx/ast-cli-javascript-wrapper-runtime-cli": {
-      "version": "1.0.37",
-      "resolved": "https://npm.pkg.github.com/download/@Checkmarx/ast-cli-javascript-wrapper-runtime-cli/1.0.37/e2928700e6ab63bd4f7b853d3b667899e23bee34",
-      "integrity": "sha512-c8IIRMUF30DMD68gozTpuoVzjxwezTeZidnvwBiB50EfjG1X+fz4SCd8wwm2BLIlczOtJLMtQ3jQlkq9pZqhdA==",
+      "version": "1.0.39",
+      "resolved": "https://npm.pkg.github.com/download/@Checkmarx/ast-cli-javascript-wrapper-runtime-cli/1.0.39/1f928d7b4fced943433df29d2741114679d6ffa9",
+      "integrity": "sha512-1pyOjakTtfIGsfk8run18/fEWNoKiJYmXl14yWYb7/rN53SyI5SNsjUqbZh5xZ7l3uPsTL8FDTjzPWkrsQbYHg==",
       "license": "ISC",
       "dependencies": {
         "async-mutex": "^0.5.0",

--- a/cxAstScan/package.json
+++ b/cxAstScan/package.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "azure-pipelines-task-lib": "4.17.3",
-    "@Checkmarx/ast-cli-javascript-wrapper-runtime-cli": "1.0.37"
+    "@Checkmarx/ast-cli-javascript-wrapper-runtime-cli": "1.0.39"
   },
   "overrides": {
     "semver": "^7.5.2",

--- a/cxAstScan/package.json
+++ b/cxAstScan/package.json
@@ -1,13 +1,18 @@
 {
   "dependencies": {
-    "azure-pipelines-task-lib": "4.17.3",
-    "@Checkmarx/ast-cli-javascript-wrapper-runtime-cli": "1.0.39"
+    "@Checkmarx/ast-cli-javascript-wrapper-runtime-cli": "file:../../../../AppData/Local/Temp/Checkmarx-ast-cli-javascript-wrapper-runtime-cli-1.0.40.tgz",
+    "azure-pipelines-task-lib": "4.17.3"
   },
   "overrides": {
     "semver": "^7.5.2",
     "underscore": "^1.13.8",
     "qs": "^6.14.2",
-     "azure-pipelines-task-lib": {
+    "brace-expansion": "2.1.4",
+    "tar": "7.5.21",
+    "js-yaml": ">=3.15.1",
+    "browserslist": "4.28.7",
+    "adm-zip": "0.5.18",
+    "azure-pipelines-task-lib": {
       "minimatch": "3.1.4"
     }
   }

--- a/cxAstScan/services/TaskRunner.ts
+++ b/cxAstScan/services/TaskRunner.ts
@@ -1,11 +1,23 @@
 import * as taskLib from "azure-pipelines-task-lib/task";
 import * as path from "path";
+import * as fs from "fs";
 import { CxWrapper } from "@Checkmarx/ast-cli-javascript-wrapper-runtime-cli";
 import { CxCommandOutput } from "@Checkmarx/ast-cli-javascript-wrapper-runtime-cli/dist/main/wrapper/CxCommandOutput";
 import { CxParamType } from "@Checkmarx/ast-cli-javascript-wrapper-runtime-cli/dist/main/wrapper/CxParamType";
 import CxScan from "@Checkmarx/ast-cli-javascript-wrapper-runtime-cli/dist/main/scan/CxScan";
 import { getConfiguration, getLogFilename } from "./Utils";
 import CxWrapperFactory from "@Checkmarx/ast-cli-javascript-wrapper-runtime-cli/dist/main/wrapper/CxWrapperFactory";
+
+function getPluginVersion(): string {
+    try {
+        const taskJsonPath = path.join(__dirname, '..', '..', 'task.json');
+        const taskJson = JSON.parse(fs.readFileSync(taskJsonPath, 'utf8'));
+        const v = taskJson.version;
+        return `_${v.Major}.${v.Minor}.${v.Patch}`;
+    } catch {
+        return '';
+    }
+}
 
 export class TaskRunner {
     cxWrapperFactory = new CxWrapperFactory();
@@ -20,7 +32,7 @@ export class TaskRunner {
         const params: Map<CxParamType, string> = new Map<CxParamType, string>();
         params.set(CxParamType.PROJECT_NAME, projectName);
         params.set(CxParamType.BRANCH, branchName);
-        params.set(CxParamType.AGENT, "Azure DevOps");
+        params.set(CxParamType.AGENT, "Azure DevOps" + getPluginVersion());
         params.set(CxParamType.ADDITIONAL_PARAMETERS, additionalParams);
 
         if (!/(?:^|\s)(--file-source|-s)(?=\s|$)/.test(additionalParams)) {

--- a/cxAstScan/services/TaskRunner.ts
+++ b/cxAstScan/services/TaskRunner.ts
@@ -14,7 +14,8 @@ function getPluginVersion(): string {
         const taskJson = JSON.parse(fs.readFileSync(taskJsonPath, 'utf8'));
         const v = taskJson.version;
         return `_${v.Major}.${v.Minor}.${v.Patch}`;
-    } catch {
+    } catch (e) {
+        console.log("Failed to read plugin version: " + e);
         return '';
     }
 }

--- a/cxAstScan/task.json
+++ b/cxAstScan/task.json
@@ -10,9 +10,9 @@
   ],
   "author": "Checkmarx",
   "version": {
-    "Major": 0,
+    "Major": 3,
     "Minor": 0,
-    "Patch": 0
+    "Patch": 23
   },
   "demands": [],
   "minimumAgentVersion": "3.232.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
       "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "license": "MIT",
       "dependencies": {
@@ -43,7 +43,7 @@
     },
     "node_modules/@babel/compat-data": {
       "version": "7.29.7",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
       "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "license": "MIT",
       "engines": {
@@ -52,7 +52,7 @@
     },
     "node_modules/@babel/core": {
       "version": "7.29.7",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/@babel/core/-/core-7.29.7.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "license": "MIT",
       "dependencies": {
@@ -82,13 +82,13 @@
     },
     "node_modules/@babel/core/node_modules/convert-source-map": {
       "version": "2.0.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "license": "MIT"
     },
     "node_modules/@babel/core/node_modules/semver": {
       "version": "6.3.1",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/semver/-/semver-6.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "license": "ISC",
       "bin": {
@@ -96,13 +96,13 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.29.7",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/@babel/generator/-/generator-7.29.7.tgz",
-      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.8.tgz",
+      "integrity": "sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.7",
-        "@babel/types": "^7.29.7",
+        "@babel/parser": "^7.29.8",
+        "@babel/types": "^7.29.8",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -113,7 +113,7 @@
     },
     "node_modules/@babel/helper-compilation-targets": {
       "version": "7.29.7",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
       "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
       "license": "MIT",
       "dependencies": {
@@ -129,7 +129,7 @@
     },
     "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
       "version": "6.3.1",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/semver/-/semver-6.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "license": "ISC",
       "bin": {
@@ -138,7 +138,7 @@
     },
     "node_modules/@babel/helper-globals": {
       "version": "7.29.7",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
       "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
       "license": "MIT",
       "engines": {
@@ -147,7 +147,7 @@
     },
     "node_modules/@babel/helper-module-imports": {
       "version": "7.29.7",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
       "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "license": "MIT",
       "dependencies": {
@@ -160,7 +160,7 @@
     },
     "node_modules/@babel/helper-module-transforms": {
       "version": "7.29.7",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
       "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "license": "MIT",
       "dependencies": {
@@ -177,7 +177,7 @@
     },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.29.7",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
       "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "license": "MIT",
       "engines": {
@@ -186,7 +186,7 @@
     },
     "node_modules/@babel/helper-validator-identifier": {
       "version": "7.29.7",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
       "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "license": "MIT",
       "engines": {
@@ -195,7 +195,7 @@
     },
     "node_modules/@babel/helper-validator-option": {
       "version": "7.29.7",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
       "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "license": "MIT",
       "engines": {
@@ -204,7 +204,7 @@
     },
     "node_modules/@babel/helpers": {
       "version": "7.29.7",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/@babel/helpers/-/helpers-7.29.7.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
       "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "license": "MIT",
       "dependencies": {
@@ -216,12 +216,12 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.7",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/@babel/parser/-/parser-7.29.7.tgz",
-      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.7"
+        "@babel/types": "^7.29.8"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -232,7 +232,7 @@
     },
     "node_modules/@babel/template": {
       "version": "7.29.7",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/@babel/template/-/template-7.29.7.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
       "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "license": "MIT",
       "dependencies": {
@@ -245,17 +245,17 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.29.7",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/@babel/traverse/-/traverse-7.29.7.tgz",
-      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.8.tgz",
+      "integrity": "sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
-        "@babel/generator": "^7.29.7",
+        "@babel/generator": "^7.29.8",
         "@babel/helper-globals": "^7.29.7",
-        "@babel/parser": "^7.29.7",
+        "@babel/parser": "^7.29.8",
         "@babel/template": "^7.29.7",
-        "@babel/types": "^7.29.7",
+        "@babel/types": "^7.29.8",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -263,9 +263,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.7",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/@babel/types/-/types-7.29.7.tgz",
-      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.29.7",
@@ -276,9 +276,9 @@
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.9.1",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
-      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.10.1.tgz",
+      "integrity": "sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -296,7 +296,7 @@
     },
     "node_modules/@eslint-community/regexpp": {
       "version": "4.12.2",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
       "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
       "dev": true,
       "license": "MIT",
@@ -306,7 +306,7 @@
     },
     "node_modules/@eslint/eslintrc": {
       "version": "2.1.4",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
       "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
       "dev": true,
       "license": "MIT",
@@ -330,7 +330,7 @@
     },
     "node_modules/@eslint/eslintrc/node_modules/minimatch": {
       "version": "3.1.4",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/minimatch/-/minimatch-3.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.4.tgz",
       "integrity": "sha512-twmL+S8+7yIsE9wsqgzU3E8/LumN3M3QELrBZ20OdmQ9jB2JvW5oZtBEmft84k/Gs5CG9mqtWc6Y9vW+JEzGxw==",
       "dev": true,
       "license": "ISC",
@@ -343,7 +343,7 @@
     },
     "node_modules/@eslint/js": {
       "version": "8.57.1",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/@eslint/js/-/js-8.57.1.tgz",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz",
       "integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
       "dev": true,
       "license": "MIT",
@@ -353,7 +353,7 @@
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.13.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
       "integrity": "sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==",
       "deprecated": "Use @eslint/config-array instead",
       "dev": true,
@@ -369,7 +369,7 @@
     },
     "node_modules/@humanwhocodes/config-array/node_modules/minimatch": {
       "version": "3.1.4",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/minimatch/-/minimatch-3.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.4.tgz",
       "integrity": "sha512-twmL+S8+7yIsE9wsqgzU3E8/LumN3M3QELrBZ20OdmQ9jB2JvW5oZtBEmft84k/Gs5CG9mqtWc6Y9vW+JEzGxw==",
       "dev": true,
       "license": "ISC",
@@ -382,7 +382,7 @@
     },
     "node_modules/@humanwhocodes/module-importer": {
       "version": "1.0.1",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
       "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
       "dev": true,
       "license": "Apache-2.0",
@@ -396,7 +396,7 @@
     },
     "node_modules/@humanwhocodes/object-schema": {
       "version": "2.0.3",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
       "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
       "deprecated": "Use @eslint/object-schema instead",
       "dev": true,
@@ -404,7 +404,7 @@
     },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
       "integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
       "license": "ISC",
       "dependencies": {
@@ -418,18 +418,9 @@
         "node": ">=8"
       }
     },
-    "node_modules/@istanbuljs/load-nyc-config/node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "license": "MIT",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/find-up": {
       "version": "4.1.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/find-up/-/find-up-4.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
       "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
       "license": "MIT",
       "dependencies": {
@@ -440,22 +431,9 @@
         "node": ">=8"
       }
     },
-    "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/locate-path": {
       "version": "5.0.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/locate-path/-/locate-path-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
       "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
       "license": "MIT",
       "dependencies": {
@@ -467,7 +445,7 @@
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/p-limit": {
       "version": "2.3.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/p-limit/-/p-limit-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
       "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
       "license": "MIT",
       "dependencies": {
@@ -482,7 +460,7 @@
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/p-locate": {
       "version": "4.1.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/p-locate/-/p-locate-4.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
       "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
       "license": "MIT",
       "dependencies": {
@@ -494,7 +472,7 @@
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/resolve-from": {
       "version": "5.0.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/resolve-from/-/resolve-from-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
       "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
       "license": "MIT",
       "engines": {
@@ -503,7 +481,7 @@
     },
     "node_modules/@istanbuljs/schema": {
       "version": "0.1.6",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
       "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
       "license": "MIT",
       "engines": {
@@ -512,7 +490,7 @@
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
       "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
       "license": "MIT",
       "dependencies": {
@@ -522,7 +500,7 @@
     },
     "node_modules/@jridgewell/remapping": {
       "version": "2.3.5",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
       "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
       "license": "MIT",
       "dependencies": {
@@ -532,7 +510,7 @@
     },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
       "license": "MIT",
       "engines": {
@@ -541,13 +519,13 @@
     },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
       "license": "MIT",
       "dependencies": {
@@ -557,7 +535,7 @@
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
       "dev": true,
       "license": "MIT",
@@ -571,7 +549,7 @@
     },
     "node_modules/@nodelib/fs.stat": {
       "version": "2.0.5",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
       "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
       "dev": true,
       "license": "MIT",
@@ -581,7 +559,7 @@
     },
     "node_modules/@nodelib/fs.walk": {
       "version": "1.2.8",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
       "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
       "dev": true,
       "license": "MIT",
@@ -595,13 +573,13 @@
     },
     "node_modules/@types/jquery": {
       "version": "4.0.1",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/@types/jquery/-/jquery-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-4.0.1.tgz",
       "integrity": "sha512-9a59A/tycXgYuPABcp6/3spSShn0NT2UOM4EfHvMumjYi4lJWTsK5SZWjhx3yRm9IHGCeWXdV2YfNsrWrft/CA==",
       "license": "MIT"
     },
     "node_modules/@types/jqueryui": {
       "version": "1.12.24",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/@types/jqueryui/-/jqueryui-1.12.24.tgz",
+      "resolved": "https://registry.npmjs.org/@types/jqueryui/-/jqueryui-1.12.24.tgz",
       "integrity": "sha512-E2sGULwzMhg4kAeOV+gYcXjg988RuPkviWCt09jLe6GGK9sHM7dTqS8H7JMuUWoZQBucIBzBAgM5o/ezKUFkeg==",
       "license": "MIT",
       "dependencies": {
@@ -610,34 +588,34 @@
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/knockout": {
       "version": "3.4.79",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/@types/knockout/-/knockout-3.4.79.tgz",
+      "resolved": "https://registry.npmjs.org/@types/knockout/-/knockout-3.4.79.tgz",
       "integrity": "sha512-jZXdMz5vDI4lE3jddr2Sk/Zm2t7ReuwYkwpE9PkHKSfGjFroY462Cce96BWG6gxR+6cOk0E+I09xidLLHTwIeA==",
       "license": "MIT"
     },
     "node_modules/@types/mocha": {
       "version": "10.0.7",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/@types/mocha/-/mocha-10.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.7.tgz",
       "integrity": "sha512-GN8yJ1mNTcFcah/wKEFIJckJx9iJLoMSzWcfRRuxz/Jk+U6KQNnml+etbtxFK8lPjzOw3zp4Ha/kjSst9fsHYw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/mousetrap": {
       "version": "1.5.34",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/@types/mousetrap/-/mousetrap-1.5.34.tgz",
+      "resolved": "https://registry.npmjs.org/@types/mousetrap/-/mousetrap-1.5.34.tgz",
       "integrity": "sha512-a2yhRIADupQfOFM75v7GfcQQLUxU705+i/xcZ3N/3PK3Xdo31SUfuCUByWPGOHB1e38m7MxTx/D8FPVsJXZKJw==",
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.19.21",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/@types/node/-/node-22.19.21.tgz",
-      "integrity": "sha512-VMeFBSCKQKmm2swI2kW51SFusDqekC6q9trBCvJ/JliDchFSuoYYKN7yVNjPthP1HKZcx3U1gI/wTcEBjEFKTA==",
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -646,32 +624,32 @@
     },
     "node_modules/@types/q": {
       "version": "0.0.32",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/@types/q/-/q-0.0.32.tgz",
+      "resolved": "https://registry.npmjs.org/@types/q/-/q-0.0.32.tgz",
       "integrity": "sha512-qYi3YV9inU/REEfxwVcGZzbS3KG/Xs90lv0Pr+lDtuVjBPGd1A+eciXzVSaRvLify132BfcvhvEjeVahrUl0Ug==",
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "15.7.37",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/@types/react/-/react-15.7.37.tgz",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-15.7.37.tgz",
       "integrity": "sha512-y9gCkVBkqZ8n6xdprjlQ4LhM9RSmbQBMy/RsLSOgZBeQNfO3FrO9c5/IYojOPn+JpSbJdL/3pCU5ghAtE2a36w==",
       "license": "MIT"
     },
     "node_modules/@types/requirejs": {
       "version": "2.1.37",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/@types/requirejs/-/requirejs-2.1.37.tgz",
+      "resolved": "https://registry.npmjs.org/@types/requirejs/-/requirejs-2.1.37.tgz",
       "integrity": "sha512-jmFgr3mwN2NSmtRP6IpZ2nfRS7ufSXuDYQ6YyPFArN8x5dARQcD/DXzT0J6NYbvquVT4pg9K9HWdi6e6DZR9iQ==",
       "license": "MIT"
     },
     "node_modules/@types/semver": {
-      "version": "7.7.1",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/@types/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-1mAINjtQCXXeLkJ9ehXkwOcBpqtLxiVtKhpUf83DdRNdQKV0iXZpaHYqRr7nj+wvxuJzoAmAwXI+sCNMv1CzLQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "5.62.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.62.0.tgz",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.62.0.tgz",
       "integrity": "sha512-TiZzBSJja/LbhNPvk6yc0JrX9XqhQ0hdh6M2svYfsHGejaKFIAGd9MQ+ERIMzLGlN/kZoYIgdxFV0PuljTKXag==",
       "dev": true,
       "license": "MIT",
@@ -706,7 +684,7 @@
     },
     "node_modules/@typescript-eslint/parser": {
       "version": "5.62.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/@typescript-eslint/parser/-/parser-5.62.0.tgz",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.62.0.tgz",
       "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -734,7 +712,7 @@
     },
     "node_modules/@typescript-eslint/scope-manager": {
       "version": "5.62.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/@typescript-eslint/scope-manager/-/scope-manager-5.62.0.tgz",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.62.0.tgz",
       "integrity": "sha512-VXuvVvZeQCQb5Zgf4HAxc04q5j+WrNAtNh9OwCsCgpKqESMTu3tF/jhZ3xG6T4NZwWl65Bg8KuS2uEvhSfLl0w==",
       "dev": true,
       "license": "MIT",
@@ -752,7 +730,7 @@
     },
     "node_modules/@typescript-eslint/type-utils": {
       "version": "5.62.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/@typescript-eslint/type-utils/-/type-utils-5.62.0.tgz",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.62.0.tgz",
       "integrity": "sha512-xsSQreu+VnfbqQpW5vnCJdq1Z3Q0U31qiWmRhr98ONQmcp/yhiPJFPq8MXiJVLiksmOKSjIldZzkebzHuCGzew==",
       "dev": true,
       "license": "MIT",
@@ -780,7 +758,7 @@
     },
     "node_modules/@typescript-eslint/types": {
       "version": "5.62.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/@typescript-eslint/types/-/types-5.62.0.tgz",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.62.0.tgz",
       "integrity": "sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ==",
       "dev": true,
       "license": "MIT",
@@ -794,7 +772,7 @@
     },
     "node_modules/@typescript-eslint/typescript-estree": {
       "version": "5.62.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/@typescript-eslint/typescript-estree/-/typescript-estree-5.62.0.tgz",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.62.0.tgz",
       "integrity": "sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -822,7 +800,7 @@
     },
     "node_modules/@typescript-eslint/utils": {
       "version": "5.62.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/@typescript-eslint/utils/-/utils-5.62.0.tgz",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.62.0.tgz",
       "integrity": "sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==",
       "dev": true,
       "license": "MIT",
@@ -849,7 +827,7 @@
     },
     "node_modules/@typescript-eslint/visitor-keys": {
       "version": "5.62.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/@typescript-eslint/visitor-keys/-/visitor-keys-5.62.0.tgz",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.62.0.tgz",
       "integrity": "sha512-07ny+LHRzQXepkGg6w0mFY41fVUNBrL2Roj/++7V1txKugfjm/Ci/qSND03r2RhlJhJYMcTn9AhhSSqQp0Ysyw==",
       "dev": true,
       "license": "MIT",
@@ -866,16 +844,16 @@
       }
     },
     "node_modules/@ungap/structured-clone": {
-      "version": "1.3.1",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/@ungap/structured-clone/-/structured-clone-1.3.1.tgz",
-      "integrity": "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.3.tgz",
+      "integrity": "sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/acorn": {
-      "version": "8.17.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/acorn/-/acorn-8.17.0.tgz",
-      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -887,7 +865,7 @@
     },
     "node_modules/acorn-jsx": {
       "version": "5.3.2",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "dev": true,
       "license": "MIT",
@@ -897,7 +875,7 @@
     },
     "node_modules/aggregate-error": {
       "version": "3.1.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/aggregate-error/-/aggregate-error-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
       "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
       "license": "MIT",
       "dependencies": {
@@ -910,7 +888,7 @@
     },
     "node_modules/ajv": {
       "version": "6.15.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/ajv/-/ajv-6.15.0.tgz",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
       "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
@@ -927,7 +905,7 @@
     },
     "node_modules/ansi-colors": {
       "version": "4.1.3",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/ansi-colors/-/ansi-colors-4.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
       "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
       "dev": true,
       "license": "MIT",
@@ -937,7 +915,7 @@
     },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "license": "MIT",
       "engines": {
@@ -946,7 +924,7 @@
     },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "license": "MIT",
       "dependencies": {
@@ -961,7 +939,7 @@
     },
     "node_modules/anymatch": {
       "version": "3.1.3",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/anymatch/-/anymatch-3.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
       "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
       "dev": true,
       "license": "ISC",
@@ -975,7 +953,7 @@
     },
     "node_modules/append-transform": {
       "version": "2.0.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/append-transform/-/append-transform-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-2.0.0.tgz",
       "integrity": "sha512-7yeyCEurROLQJFv5Xj4lEGTy0borxepjFv1g22oAdqFu//SrAlDl1O1Nxx15SH1RoliUml6p8dwJW9jvZughhg==",
       "license": "MIT",
       "dependencies": {
@@ -987,20 +965,19 @@
     },
     "node_modules/archy": {
       "version": "1.0.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/archy/-/archy-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
       "integrity": "sha512-Xg+9RwCg/0p32teKdGMPTPnVXKD0w3DfHnFTficozsAgsvq2XenPJq/MYpzzQ/v8zrOyJn6Ds39VA4JIDwFfqw==",
       "license": "MIT"
     },
     "node_modules/argparse": {
       "version": "2.0.1",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/argparse/-/argparse-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/array-union": {
       "version": "2.1.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/array-union/-/array-union-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
       "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
       "dev": true,
       "license": "MIT",
@@ -1010,14 +987,14 @@
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/balanced-match/-/balanced-match-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.37",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/baseline-browser-mapping/-/baseline-browser-mapping-2.10.37.tgz",
-      "integrity": "sha512-girxaJ7WZssDOFhzCGZTDKoTa1gk6A1TbflaYTpykLJ4UU9Fz9kx1aREM8JCuoVHbL8X8T/mJg7w2oYSq72Oig==",
+      "version": "2.11.18",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.18.tgz",
+      "integrity": "sha512-1iEmLEYSiE1SeBoAfPo/Mnx3PzfzHUkDK61ASkCpuk3YXugYLH5DYK1SzqV55F8FMI6s0F+/tCP7Polz1QRjxw==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -1028,7 +1005,7 @@
     },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
       "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
       "dev": true,
       "license": "MIT",
@@ -1040,18 +1017,17 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
+        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/braces": {
       "version": "3.0.3",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/braces/-/braces-3.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
       "license": "MIT",
@@ -1064,15 +1040,15 @@
     },
     "node_modules/browser-stdout": {
       "version": "1.3.1",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/browserslist": {
-      "version": "4.28.2",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/browserslist/-/browserslist-4.28.2.tgz",
-      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "version": "4.28.7",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.7.tgz",
+      "integrity": "sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw==",
       "funding": [
         {
           "type": "opencollective",
@@ -1089,10 +1065,10 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.10.12",
-        "caniuse-lite": "^1.0.30001782",
-        "electron-to-chromium": "^1.5.328",
-        "node-releases": "^2.0.36",
+        "baseline-browser-mapping": "^2.10.44",
+        "caniuse-lite": "^1.0.30001806",
+        "electron-to-chromium": "^1.5.393",
+        "node-releases": "^2.0.51",
         "update-browserslist-db": "^1.2.3"
       },
       "bin": {
@@ -1104,7 +1080,7 @@
     },
     "node_modules/caching-transform": {
       "version": "4.0.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/caching-transform/-/caching-transform-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-4.0.0.tgz",
       "integrity": "sha512-kpqOvwXnjjN44D89K5ccQC+RUrsy7jB/XLlRrx0D7/2HNcTPqzsb6XgYoErwko6QsV184CA2YgS1fxDiiDZMWA==",
       "license": "MIT",
       "dependencies": {
@@ -1119,7 +1095,7 @@
     },
     "node_modules/callsites": {
       "version": "3.1.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/callsites/-/callsites-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "dev": true,
       "license": "MIT",
@@ -1129,7 +1105,7 @@
     },
     "node_modules/camelcase": {
       "version": "5.3.1",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/camelcase/-/camelcase-5.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
       "license": "MIT",
       "engines": {
@@ -1137,9 +1113,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001799",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
-      "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
+      "version": "1.0.30001809",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001809.tgz",
+      "integrity": "sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -1158,7 +1134,7 @@
     },
     "node_modules/chalk": {
       "version": "4.1.2",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/chalk/-/chalk-4.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
       "license": "MIT",
@@ -1175,7 +1151,7 @@
     },
     "node_modules/chokidar": {
       "version": "3.6.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/chokidar/-/chokidar-3.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
       "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
       "dev": true,
       "license": "MIT",
@@ -1200,7 +1176,7 @@
     },
     "node_modules/chokidar/node_modules/glob-parent": {
       "version": "5.1.2",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/glob-parent/-/glob-parent-5.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "dev": true,
       "license": "ISC",
@@ -1213,7 +1189,7 @@
     },
     "node_modules/clean-stack": {
       "version": "2.2.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/clean-stack/-/clean-stack-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
       "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
       "license": "MIT",
       "engines": {
@@ -1222,7 +1198,7 @@
     },
     "node_modules/cliui": {
       "version": "7.0.4",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/cliui/-/cliui-7.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
       "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
       "dev": true,
       "license": "ISC",
@@ -1234,7 +1210,7 @@
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/color-convert/-/color-convert-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "license": "MIT",
       "dependencies": {
@@ -1246,31 +1222,25 @@
     },
     "node_modules/color-name": {
       "version": "1.1.4",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/color-name/-/color-name-1.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
     },
     "node_modules/commondir": {
       "version": "1.0.1",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/commondir/-/commondir-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
       "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
-      "license": "MIT"
-    },
-    "node_modules/concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "license": "MIT"
     },
     "node_modules/convert-source-map": {
       "version": "1.9.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/convert-source-map/-/convert-source-map-1.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
       "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
       "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "license": "MIT",
       "dependencies": {
@@ -1284,7 +1254,7 @@
     },
     "node_modules/debug": {
       "version": "4.4.3",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/debug/-/debug-4.4.3.tgz",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "license": "MIT",
       "dependencies": {
@@ -1301,7 +1271,7 @@
     },
     "node_modules/decamelize": {
       "version": "1.2.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/decamelize/-/decamelize-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
       "license": "MIT",
       "engines": {
@@ -1310,14 +1280,14 @@
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/deep-is/-/deep-is-0.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/default-require-extensions": {
       "version": "3.0.1",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/default-require-extensions/-/default-require-extensions-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-3.0.1.tgz",
       "integrity": "sha512-eXTJmRbm2TIt9MgWTsOH1wEuhew6XGZcMeGKCtLedIg/NCsg1iBePXkceTdK4Fii7pzmN9tGsZhKzZ4h7O/fxw==",
       "license": "MIT",
       "dependencies": {
@@ -1332,7 +1302,7 @@
     },
     "node_modules/diff": {
       "version": "5.2.2",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/diff/-/diff-5.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.2.tgz",
       "integrity": "sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==",
       "dev": true,
       "license": "BSD-3-Clause",
@@ -1342,7 +1312,7 @@
     },
     "node_modules/dir-glob": {
       "version": "3.0.1",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/dir-glob/-/dir-glob-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
       "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
       "dev": true,
       "license": "MIT",
@@ -1355,7 +1325,7 @@
     },
     "node_modules/doctrine": {
       "version": "3.0.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/doctrine/-/doctrine-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
       "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
       "dev": true,
       "license": "Apache-2.0",
@@ -1367,26 +1337,26 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.375",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/electron-to-chromium/-/electron-to-chromium-1.5.375.tgz",
-      "integrity": "sha512-ZWP5eB4BVPW/ZYo9252hQZHZ5XavtsTgpbhcmMmRwymavC5AsLWQWBPaKMeNd2LW0KGby5HPXvj7+sr4ta5j/Q==",
+      "version": "1.5.412",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.412.tgz",
+      "integrity": "sha512-z4rMe3esBzlzovKHj4gxJnsCGZRK5l4baUvm+gCGJBPE+gsyUMKsuU9tnEUtI1dOebXz1ytAPGjvXhmQ7rIPwA==",
       "license": "ISC"
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "license": "MIT"
     },
     "node_modules/es6-error": {
       "version": "4.1.1",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/es6-error/-/es6-error-4.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
       "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
       "license": "MIT"
     },
     "node_modules/escalade": {
       "version": "3.2.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/escalade/-/escalade-3.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
       "license": "MIT",
       "engines": {
@@ -1395,7 +1365,7 @@
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
       "dev": true,
       "license": "MIT",
@@ -1408,7 +1378,7 @@
     },
     "node_modules/eslint": {
       "version": "8.57.1",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/eslint/-/eslint-8.57.1.tgz",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
       "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
@@ -1465,7 +1435,7 @@
     },
     "node_modules/eslint-scope": {
       "version": "5.1.1",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/eslint-scope/-/eslint-scope-5.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
       "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -1479,7 +1449,7 @@
     },
     "node_modules/eslint-visitor-keys": {
       "version": "3.4.3",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
       "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
       "dev": true,
       "license": "Apache-2.0",
@@ -1492,7 +1462,7 @@
     },
     "node_modules/eslint/node_modules/eslint-scope": {
       "version": "7.2.2",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/eslint-scope/-/eslint-scope-7.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
       "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -1509,7 +1479,7 @@
     },
     "node_modules/eslint/node_modules/estraverse": {
       "version": "5.3.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/estraverse/-/estraverse-5.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -1519,7 +1489,7 @@
     },
     "node_modules/espree": {
       "version": "9.6.1",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/espree/-/espree-9.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
       "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -1535,22 +1505,9 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/esprima": {
-      "version": "4.0.1",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "license": "BSD-2-Clause",
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/esquery": {
       "version": "1.7.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/esquery/-/esquery-1.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
       "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
       "dev": true,
       "license": "BSD-3-Clause",
@@ -1563,7 +1520,7 @@
     },
     "node_modules/esquery/node_modules/estraverse": {
       "version": "5.3.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/estraverse/-/estraverse-5.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -1573,7 +1530,7 @@
     },
     "node_modules/esrecurse": {
       "version": "4.3.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/esrecurse/-/esrecurse-4.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
       "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -1586,7 +1543,7 @@
     },
     "node_modules/esrecurse/node_modules/estraverse": {
       "version": "5.3.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/estraverse/-/estraverse-5.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -1596,7 +1553,7 @@
     },
     "node_modules/estraverse": {
       "version": "4.3.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/estraverse/-/estraverse-4.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
       "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -1606,7 +1563,7 @@
     },
     "node_modules/esutils": {
       "version": "2.0.3",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/esutils/-/esutils-2.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -1616,14 +1573,14 @@
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-glob": {
       "version": "3.3.3",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/fast-glob/-/fast-glob-3.3.3.tgz",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
       "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
       "dev": true,
       "license": "MIT",
@@ -1640,7 +1597,7 @@
     },
     "node_modules/fast-glob/node_modules/glob-parent": {
       "version": "5.1.2",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/glob-parent/-/glob-parent-5.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "dev": true,
       "license": "ISC",
@@ -1653,21 +1610,21 @@
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/fastq": {
       "version": "1.20.1",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/fastq/-/fastq-1.20.1.tgz",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
       "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
       "dev": true,
       "license": "ISC",
@@ -1677,7 +1634,7 @@
     },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
       "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
       "dev": true,
       "license": "MIT",
@@ -1690,7 +1647,7 @@
     },
     "node_modules/fill-range": {
       "version": "7.1.1",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/fill-range/-/fill-range-7.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
       "license": "MIT",
@@ -1703,7 +1660,7 @@
     },
     "node_modules/find-cache-dir": {
       "version": "3.3.2",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
       "integrity": "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==",
       "license": "MIT",
       "dependencies": {
@@ -1720,7 +1677,7 @@
     },
     "node_modules/find-up": {
       "version": "5.0.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/find-up/-/find-up-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
       "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
       "dev": true,
       "license": "MIT",
@@ -1737,7 +1694,7 @@
     },
     "node_modules/flat": {
       "version": "5.0.2",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/flat/-/flat-5.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
       "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
       "dev": true,
       "license": "BSD-3-Clause",
@@ -1747,7 +1704,7 @@
     },
     "node_modules/flat-cache": {
       "version": "3.2.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/flat-cache/-/flat-cache-3.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
       "integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
       "dev": true,
       "license": "MIT",
@@ -1761,15 +1718,15 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.4.2",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/flatted/-/flatted-3.4.2.tgz",
-      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.4.tgz",
+      "integrity": "sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/foreground-child": {
       "version": "3.3.1",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/foreground-child/-/foreground-child-3.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
       "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
       "license": "ISC",
       "dependencies": {
@@ -1785,7 +1742,7 @@
     },
     "node_modules/foreground-child/node_modules/signal-exit": {
       "version": "4.1.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/signal-exit/-/signal-exit-4.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
       "license": "ISC",
       "engines": {
@@ -1797,7 +1754,7 @@
     },
     "node_modules/fromentries": {
       "version": "1.3.2",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/fromentries/-/fromentries-1.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/fromentries/-/fromentries-1.3.2.tgz",
       "integrity": "sha512-cHEpEQHUg0f8XdtZCc2ZAhrHzKzT0MrFUTcvx+hfxYu7rGMDc5SKoXFh+n4YigxsHXRzc6OrCshdR1bWH6HHyg==",
       "funding": [
         {
@@ -1817,13 +1774,13 @@
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "license": "ISC"
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/fsevents/-/fsevents-2.3.3.tgz",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
       "dev": true,
       "hasInstallScript": true,
@@ -1838,7 +1795,7 @@
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
       "license": "MIT",
       "engines": {
@@ -1847,7 +1804,7 @@
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "license": "ISC",
       "engines": {
@@ -1856,7 +1813,7 @@
     },
     "node_modules/get-package-type": {
       "version": "0.1.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/get-package-type/-/get-package-type-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
       "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
       "license": "MIT",
       "engines": {
@@ -1865,7 +1822,7 @@
     },
     "node_modules/glob": {
       "version": "8.1.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/glob/-/glob-8.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
       "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
       "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "dev": true,
@@ -1886,7 +1843,7 @@
     },
     "node_modules/glob-parent": {
       "version": "6.0.2",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/glob-parent/-/glob-parent-6.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
       "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
       "dev": true,
       "license": "ISC",
@@ -1897,19 +1854,9 @@
         "node": ">=10.13.0"
       }
     },
-    "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
     "node_modules/glob/node_modules/minimatch": {
       "version": "5.1.9",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/minimatch/-/minimatch-5.1.9.tgz",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
       "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
       "dev": true,
       "license": "ISC",
@@ -1922,7 +1869,7 @@
     },
     "node_modules/globals": {
       "version": "13.24.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/globals/-/globals-13.24.0.tgz",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
       "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
       "dev": true,
       "license": "MIT",
@@ -1938,7 +1885,7 @@
     },
     "node_modules/globby": {
       "version": "11.1.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/globby/-/globby-11.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
       "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
       "dev": true,
       "license": "MIT",
@@ -1959,20 +1906,20 @@
     },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "license": "ISC"
     },
     "node_modules/graphemer": {
       "version": "1.4.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/graphemer/-/graphemer-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/has-flag/-/has-flag-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "license": "MIT",
       "engines": {
@@ -1981,7 +1928,7 @@
     },
     "node_modules/hasha": {
       "version": "5.2.2",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/hasha/-/hasha-5.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/hasha/-/hasha-5.2.2.tgz",
       "integrity": "sha512-Hrp5vIK/xr5SkeN2onO32H0MgNZ0f17HRNH39WfL0SYUNOTZ5Lz1TJ8Pajo/87dYGEFlLMm7mIc/k/s6Bvz9HQ==",
       "license": "MIT",
       "dependencies": {
@@ -1997,7 +1944,7 @@
     },
     "node_modules/hasha/node_modules/type-fest": {
       "version": "0.8.1",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/type-fest/-/type-fest-0.8.1.tgz",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
       "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
       "license": "(MIT OR CC0-1.0)",
       "engines": {
@@ -2006,7 +1953,7 @@
     },
     "node_modules/he": {
       "version": "1.2.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/he/-/he-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true,
       "license": "MIT",
@@ -2016,13 +1963,13 @@
     },
     "node_modules/html-escaper": {
       "version": "2.0.2",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/html-escaper/-/html-escaper-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "license": "MIT"
     },
     "node_modules/ignore": {
       "version": "5.3.2",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/ignore/-/ignore-5.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
       "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
       "dev": true,
       "license": "MIT",
@@ -2032,7 +1979,7 @@
     },
     "node_modules/import-fresh": {
       "version": "3.3.1",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/import-fresh/-/import-fresh-3.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
       "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
       "dev": true,
       "license": "MIT",
@@ -2049,7 +1996,7 @@
     },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
       "license": "MIT",
       "engines": {
@@ -2058,7 +2005,7 @@
     },
     "node_modules/indent-string": {
       "version": "4.0.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/indent-string/-/indent-string-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
       "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
       "license": "MIT",
       "engines": {
@@ -2067,7 +2014,7 @@
     },
     "node_modules/inflight": {
       "version": "1.0.6",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/inflight/-/inflight-1.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
       "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
       "license": "ISC",
@@ -2078,13 +2025,13 @@
     },
     "node_modules/inherits": {
       "version": "2.0.4",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/inherits/-/inherits-2.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
       "dev": true,
       "license": "MIT",
@@ -2097,7 +2044,7 @@
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/is-extglob/-/is-extglob-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
       "dev": true,
       "license": "MIT",
@@ -2107,7 +2054,7 @@
     },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "license": "MIT",
       "engines": {
@@ -2116,7 +2063,7 @@
     },
     "node_modules/is-glob": {
       "version": "4.0.3",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/is-glob/-/is-glob-4.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
       "dev": true,
       "license": "MIT",
@@ -2129,7 +2076,7 @@
     },
     "node_modules/is-number": {
       "version": "7.0.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/is-number/-/is-number-7.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "dev": true,
       "license": "MIT",
@@ -2139,7 +2086,7 @@
     },
     "node_modules/is-path-inside": {
       "version": "3.0.3",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/is-path-inside/-/is-path-inside-3.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
       "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
       "dev": true,
       "license": "MIT",
@@ -2149,7 +2096,7 @@
     },
     "node_modules/is-plain-obj": {
       "version": "2.1.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
       "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
       "dev": true,
       "license": "MIT",
@@ -2159,7 +2106,7 @@
     },
     "node_modules/is-stream": {
       "version": "2.0.1",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/is-stream/-/is-stream-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
       "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
       "license": "MIT",
       "engines": {
@@ -2171,13 +2118,13 @@
     },
     "node_modules/is-typedarray": {
       "version": "1.0.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
       "license": "MIT"
     },
     "node_modules/is-unicode-supported": {
       "version": "0.1.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
       "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
       "dev": true,
       "license": "MIT",
@@ -2190,7 +2137,7 @@
     },
     "node_modules/is-windows": {
       "version": "1.0.2",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/is-windows/-/is-windows-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
       "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
       "license": "MIT",
       "engines": {
@@ -2199,13 +2146,13 @@
     },
     "node_modules/isexe": {
       "version": "2.0.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/isexe/-/isexe-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
       "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
       "license": "BSD-3-Clause",
       "engines": {
@@ -2214,7 +2161,7 @@
     },
     "node_modules/istanbul-lib-hook": {
       "version": "3.0.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/istanbul-lib-hook/-/istanbul-lib-hook-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-3.0.0.tgz",
       "integrity": "sha512-Pt/uge1Q9s+5VAZ+pCo16TYMWPBIl+oaNIjgLQxcX0itS6ueeaA+pEfThZpH8WxhFgCiEb8sAJY6MdUKgiIWaQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -2226,7 +2173,7 @@
     },
     "node_modules/istanbul-lib-instrument": {
       "version": "6.0.3",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz",
       "integrity": "sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==",
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -2242,7 +2189,7 @@
     },
     "node_modules/istanbul-lib-processinfo": {
       "version": "2.0.3",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/istanbul-lib-processinfo/-/istanbul-lib-processinfo-2.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-processinfo/-/istanbul-lib-processinfo-2.0.3.tgz",
       "integrity": "sha512-NkwHbo3E00oybX6NGJi6ar0B29vxyvNwoC7eJ4G4Yq28UfY758Hgn/heV8VRFhevPED4LXfFz0DQ8z/0kw9zMg==",
       "license": "ISC",
       "dependencies": {
@@ -2259,7 +2206,7 @@
     },
     "node_modules/istanbul-lib-report": {
       "version": "3.0.1",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
       "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -2273,7 +2220,7 @@
     },
     "node_modules/istanbul-lib-report/node_modules/make-dir": {
       "version": "4.0.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/make-dir/-/make-dir-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
       "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
       "license": "MIT",
       "dependencies": {
@@ -2288,7 +2235,7 @@
     },
     "node_modules/istanbul-lib-source-maps": {
       "version": "4.0.1",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz",
       "integrity": "sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==",
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -2302,7 +2249,7 @@
     },
     "node_modules/istanbul-reports": {
       "version": "3.2.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
       "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -2315,15 +2262,14 @@
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/js-tokens/-/js-tokens-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
-      "dev": true,
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.3.0.tgz",
+      "integrity": "sha512-muutsYr+e2+d3rTgUGslq5rxbBlUy3cJ61IsHag2QNDQV+7zXWjkUpmALIajhrlLlrgRUiymj6U3zUr/TMK84Q==",
       "funding": [
         {
           "type": "github",
@@ -2339,12 +2285,12 @@
         "argparse": "^2.0.1"
       },
       "bin": {
-        "js-yaml": "bin/js-yaml.js"
+        "js-yaml": "bin/js-yaml.mjs"
       }
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/jsesc/-/jsesc-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
       "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
       "license": "MIT",
       "bin": {
@@ -2356,28 +2302,28 @@
     },
     "node_modules/json-buffer": {
       "version": "3.0.1",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/json-buffer/-/json-buffer-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/json5": {
       "version": "2.2.3",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/json5/-/json5-2.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "license": "MIT",
       "bin": {
@@ -2389,7 +2335,7 @@
     },
     "node_modules/keyv": {
       "version": "4.5.4",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/keyv/-/keyv-4.5.4.tgz",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
       "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
       "dev": true,
       "license": "MIT",
@@ -2399,7 +2345,7 @@
     },
     "node_modules/levn": {
       "version": "0.4.1",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/levn/-/levn-0.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
       "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
       "dev": true,
       "license": "MIT",
@@ -2413,7 +2359,7 @@
     },
     "node_modules/locate-path": {
       "version": "6.0.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/locate-path/-/locate-path-6.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
       "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
       "dev": true,
       "license": "MIT",
@@ -2429,20 +2375,20 @@
     },
     "node_modules/lodash.flattendeep": {
       "version": "4.4.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
       "integrity": "sha512-uHaJFihxmJcEX3kT4I23ABqKKalJ/zDrDg0lsFtc1h+3uw49SIJ5beyhx5ExVRti3AvKoOJngIj7xz3oylPdWQ==",
       "license": "MIT"
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/log-symbols": {
       "version": "4.1.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/log-symbols/-/log-symbols-4.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
       "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
       "dev": true,
       "license": "MIT",
@@ -2459,7 +2405,7 @@
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/lru-cache/-/lru-cache-5.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
       "license": "ISC",
       "dependencies": {
@@ -2468,7 +2414,7 @@
     },
     "node_modules/make-dir": {
       "version": "3.1.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/make-dir/-/make-dir-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
       "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
       "license": "MIT",
       "dependencies": {
@@ -2483,7 +2429,7 @@
     },
     "node_modules/make-dir/node_modules/semver": {
       "version": "6.3.1",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/semver/-/semver-6.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "license": "ISC",
       "bin": {
@@ -2492,7 +2438,7 @@
     },
     "node_modules/merge2": {
       "version": "1.4.1",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/merge2/-/merge2-1.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
       "dev": true,
       "license": "MIT",
@@ -2502,7 +2448,7 @@
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/micromatch/-/micromatch-4.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
       "license": "MIT",
@@ -2516,7 +2462,7 @@
     },
     "node_modules/minimatch": {
       "version": "3.1.5",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/minimatch/-/minimatch-3.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
       "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "license": "ISC",
       "dependencies": {
@@ -2528,7 +2474,7 @@
     },
     "node_modules/mocha": {
       "version": "10.7.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/mocha/-/mocha-10.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.7.0.tgz",
       "integrity": "sha512-v8/rBWr2VO5YkspYINnvu81inSz2y3ODJrhO175/Exzor1RcEZZkizgE2A+w/CAXXoESS8Kys5E62dOHGHzULA==",
       "dev": true,
       "license": "MIT",
@@ -2562,19 +2508,9 @@
         "node": ">= 14.0.0"
       }
     },
-    "node_modules/mocha/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
     "node_modules/mocha/node_modules/minimatch": {
       "version": "5.1.9",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/minimatch/-/minimatch-5.1.9.tgz",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
       "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
       "dev": true,
       "license": "ISC",
@@ -2587,7 +2523,7 @@
     },
     "node_modules/mocha/node_modules/supports-color": {
       "version": "8.1.1",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/supports-color/-/supports-color-8.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
       "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
       "dev": true,
       "license": "MIT",
@@ -2603,27 +2539,27 @@
     },
     "node_modules/ms": {
       "version": "2.1.3",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/ms/-/ms-2.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/natural-compare/-/natural-compare-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/natural-compare-lite": {
       "version": "1.4.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
       "integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/node-preload": {
       "version": "0.2.1",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/node-preload/-/node-preload-0.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/node-preload/-/node-preload-0.2.1.tgz",
       "integrity": "sha512-RM5oyBy45cLEoHqCeh+MNuFAxO0vTFBLskvQbOKnEE7YTTSN4tbN8QWDIPQ6L+WvKsB/qLEGpYe2ZZ9d4W9OIQ==",
       "license": "MIT",
       "dependencies": {
@@ -2634,9 +2570,9 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.47",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/node-releases/-/node-releases-2.0.47.tgz",
-      "integrity": "sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==",
+      "version": "2.0.53",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.53.tgz",
+      "integrity": "sha512-D9UOmYG3UH1V+ENW56t5QXBwJw1YEY18ruVeus89Rw+SyIgjPkCO84bRzO3uNIYosJbNwiabWVn48o3uJLjxFQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -2644,7 +2580,7 @@
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/normalize-path/-/normalize-path-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true,
       "license": "MIT",
@@ -2654,7 +2590,7 @@
     },
     "node_modules/nyc": {
       "version": "17.1.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/nyc/-/nyc-17.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/nyc/-/nyc-17.1.0.tgz",
       "integrity": "sha512-U42vQ4czpKa0QdI1hu950XuNhYqgoM+ZF1HT+VuUHL9hPfDPVvNQyltmMqdE9bUHMVa+8yNbc3QKTj8zQhlVxQ==",
       "license": "ISC",
       "dependencies": {
@@ -2695,7 +2631,7 @@
     },
     "node_modules/nyc/node_modules/cliui": {
       "version": "6.0.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/cliui/-/cliui-6.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
       "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
       "license": "ISC",
       "dependencies": {
@@ -2706,7 +2642,7 @@
     },
     "node_modules/nyc/node_modules/find-up": {
       "version": "4.1.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/find-up/-/find-up-4.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
       "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
       "license": "MIT",
       "dependencies": {
@@ -2719,7 +2655,7 @@
     },
     "node_modules/nyc/node_modules/glob": {
       "version": "7.2.3",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/glob/-/glob-7.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
       "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "license": "ISC",
@@ -2740,7 +2676,7 @@
     },
     "node_modules/nyc/node_modules/locate-path": {
       "version": "5.0.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/locate-path/-/locate-path-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
       "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
       "license": "MIT",
       "dependencies": {
@@ -2752,7 +2688,7 @@
     },
     "node_modules/nyc/node_modules/p-limit": {
       "version": "2.3.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/p-limit/-/p-limit-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
       "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
       "license": "MIT",
       "dependencies": {
@@ -2767,7 +2703,7 @@
     },
     "node_modules/nyc/node_modules/p-locate": {
       "version": "4.1.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/p-locate/-/p-locate-4.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
       "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
       "license": "MIT",
       "dependencies": {
@@ -2779,7 +2715,7 @@
     },
     "node_modules/nyc/node_modules/resolve-from": {
       "version": "5.0.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/resolve-from/-/resolve-from-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
       "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
       "license": "MIT",
       "engines": {
@@ -2788,7 +2724,7 @@
     },
     "node_modules/nyc/node_modules/wrap-ansi": {
       "version": "6.2.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
       "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
       "license": "MIT",
       "dependencies": {
@@ -2802,13 +2738,13 @@
     },
     "node_modules/nyc/node_modules/y18n": {
       "version": "4.0.3",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/y18n/-/y18n-4.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
       "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
       "license": "ISC"
     },
     "node_modules/nyc/node_modules/yargs": {
       "version": "15.4.1",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/yargs/-/yargs-15.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
       "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
       "license": "MIT",
       "dependencies": {
@@ -2830,7 +2766,7 @@
     },
     "node_modules/nyc/node_modules/yargs-parser": {
       "version": "18.1.3",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
       "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
       "license": "ISC",
       "dependencies": {
@@ -2843,7 +2779,7 @@
     },
     "node_modules/once": {
       "version": "1.4.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/once/-/once-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "license": "ISC",
       "dependencies": {
@@ -2852,7 +2788,7 @@
     },
     "node_modules/optionator": {
       "version": "0.9.4",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/optionator/-/optionator-0.9.4.tgz",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
       "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
       "dev": true,
       "license": "MIT",
@@ -2870,7 +2806,7 @@
     },
     "node_modules/p-limit": {
       "version": "3.1.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/p-limit/-/p-limit-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
       "dev": true,
       "license": "MIT",
@@ -2886,7 +2822,7 @@
     },
     "node_modules/p-locate": {
       "version": "5.0.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/p-locate/-/p-locate-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
       "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
       "dev": true,
       "license": "MIT",
@@ -2902,7 +2838,7 @@
     },
     "node_modules/p-map": {
       "version": "3.0.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/p-map/-/p-map-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-3.0.0.tgz",
       "integrity": "sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==",
       "license": "MIT",
       "dependencies": {
@@ -2914,7 +2850,7 @@
     },
     "node_modules/p-try": {
       "version": "2.2.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/p-try/-/p-try-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
       "license": "MIT",
       "engines": {
@@ -2923,7 +2859,7 @@
     },
     "node_modules/package-hash": {
       "version": "4.0.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/package-hash/-/package-hash-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/package-hash/-/package-hash-4.0.0.tgz",
       "integrity": "sha512-whdkPIooSu/bASggZ96BWVvZTRMOFxnyUG5PnTSGKoJE2gd5mbVNmR2Nj20QFzxYYgAXpoqC+AiXzl+UMRh7zQ==",
       "license": "ISC",
       "dependencies": {
@@ -2938,7 +2874,7 @@
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/parent-module/-/parent-module-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
       "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
       "dev": true,
       "license": "MIT",
@@ -2951,7 +2887,7 @@
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/path-exists/-/path-exists-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
       "license": "MIT",
       "engines": {
@@ -2960,7 +2896,7 @@
     },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
       "license": "MIT",
       "engines": {
@@ -2969,7 +2905,7 @@
     },
     "node_modules/path-key": {
       "version": "3.1.1",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/path-key/-/path-key-3.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "license": "MIT",
       "engines": {
@@ -2978,7 +2914,7 @@
     },
     "node_modules/path-type": {
       "version": "4.0.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/path-type/-/path-type-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
       "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
       "dev": true,
       "license": "MIT",
@@ -2988,13 +2924,13 @@
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/picocolors/-/picocolors-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "2.3.2",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/picomatch/-/picomatch-2.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
       "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
@@ -3007,7 +2943,7 @@
     },
     "node_modules/pkg-dir": {
       "version": "4.2.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/pkg-dir/-/pkg-dir-4.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
       "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
       "license": "MIT",
       "dependencies": {
@@ -3019,7 +2955,7 @@
     },
     "node_modules/pkg-dir/node_modules/find-up": {
       "version": "4.1.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/find-up/-/find-up-4.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
       "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
       "license": "MIT",
       "dependencies": {
@@ -3032,7 +2968,7 @@
     },
     "node_modules/pkg-dir/node_modules/locate-path": {
       "version": "5.0.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/locate-path/-/locate-path-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
       "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
       "license": "MIT",
       "dependencies": {
@@ -3044,7 +2980,7 @@
     },
     "node_modules/pkg-dir/node_modules/p-limit": {
       "version": "2.3.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/p-limit/-/p-limit-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
       "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
       "license": "MIT",
       "dependencies": {
@@ -3059,7 +2995,7 @@
     },
     "node_modules/pkg-dir/node_modules/p-locate": {
       "version": "4.1.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/p-locate/-/p-locate-4.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
       "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
       "license": "MIT",
       "dependencies": {
@@ -3071,7 +3007,7 @@
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "dev": true,
       "license": "MIT",
@@ -3081,7 +3017,7 @@
     },
     "node_modules/process-on-spawn": {
       "version": "1.1.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/process-on-spawn/-/process-on-spawn-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/process-on-spawn/-/process-on-spawn-1.1.0.tgz",
       "integrity": "sha512-JOnOPQ/8TZgjs1JIH/m9ni7FfimjNa/PRx7y/Wb5qdItsnhO0jE4AT7fC0HjC28DUQWDr50dwSYZLdRMlqDq3Q==",
       "license": "MIT",
       "dependencies": {
@@ -3093,7 +3029,7 @@
     },
     "node_modules/punycode": {
       "version": "2.3.1",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/punycode/-/punycode-2.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true,
       "license": "MIT",
@@ -3103,7 +3039,7 @@
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
       "dev": true,
       "funding": [
@@ -3124,7 +3060,7 @@
     },
     "node_modules/readdirp": {
       "version": "3.6.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/readdirp/-/readdirp-3.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
       "dev": true,
       "license": "MIT",
@@ -3137,7 +3073,7 @@
     },
     "node_modules/release-zalgo": {
       "version": "1.0.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/release-zalgo/-/release-zalgo-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/release-zalgo/-/release-zalgo-1.0.0.tgz",
       "integrity": "sha512-gUAyHVHPPC5wdqX/LG4LWtRYtgjxyX78oanFNTMMyFEfOqdC54s3eE82imuWKbOeqYht2CrNf64Qb8vgmmtZGA==",
       "license": "ISC",
       "dependencies": {
@@ -3149,7 +3085,7 @@
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/require-directory/-/require-directory-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "license": "MIT",
       "engines": {
@@ -3158,13 +3094,13 @@
     },
     "node_modules/require-main-filename": {
       "version": "2.0.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "license": "ISC"
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/resolve-from/-/resolve-from-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
       "dev": true,
       "license": "MIT",
@@ -3174,7 +3110,7 @@
     },
     "node_modules/reusify": {
       "version": "1.1.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/reusify/-/reusify-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
       "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
       "dev": true,
       "license": "MIT",
@@ -3185,7 +3121,7 @@
     },
     "node_modules/rimraf": {
       "version": "3.0.2",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/rimraf/-/rimraf-3.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
       "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
       "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "license": "ISC",
@@ -3201,7 +3137,7 @@
     },
     "node_modules/rimraf/node_modules/glob": {
       "version": "7.2.3",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/glob/-/glob-7.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
       "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "license": "ISC",
@@ -3222,7 +3158,7 @@
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/run-parallel/-/run-parallel-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
       "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
       "dev": true,
       "funding": [
@@ -3245,9 +3181,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.8.4",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/semver/-/semver-7.8.4.tgz",
-      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -3257,9 +3193,9 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "7.0.5",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
-      "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.1.0.tgz",
+      "integrity": "sha512-RNEqWOyhhUQYN9V1GfHwu9AR/g+NTciH6Z5u3/no6X3/w+04J2lVDL+svFQVXgXrEGBMG2puMVN3gq2SNGuTGw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -3268,13 +3204,13 @@
     },
     "node_modules/set-blocking": {
       "version": "2.0.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/set-blocking/-/set-blocking-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
       "license": "ISC"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/shebang-command/-/shebang-command-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
       "license": "MIT",
       "dependencies": {
@@ -3286,7 +3222,7 @@
     },
     "node_modules/shebang-regex": {
       "version": "3.0.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "license": "MIT",
       "engines": {
@@ -3295,13 +3231,13 @@
     },
     "node_modules/signal-exit": {
       "version": "3.0.7",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/signal-exit/-/signal-exit-3.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "license": "ISC"
     },
     "node_modules/slash": {
       "version": "3.0.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/slash/-/slash-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
       "dev": true,
       "license": "MIT",
@@ -3311,7 +3247,7 @@
     },
     "node_modules/source-map": {
       "version": "0.6.1",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/source-map/-/source-map-0.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "license": "BSD-3-Clause",
       "engines": {
@@ -3320,7 +3256,7 @@
     },
     "node_modules/spawn-wrap": {
       "version": "2.0.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/spawn-wrap/-/spawn-wrap-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-2.0.0.tgz",
       "integrity": "sha512-EeajNjfN9zMnULLwhZZQU3GWBoFNkbngTUPfaawT4RkMiviTxcX0qfhVbGey39mfctfDHkWtuecgQ8NJcyQWHg==",
       "license": "ISC",
       "dependencies": {
@@ -3337,7 +3273,7 @@
     },
     "node_modules/spawn-wrap/node_modules/foreground-child": {
       "version": "2.0.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/foreground-child/-/foreground-child-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-2.0.0.tgz",
       "integrity": "sha512-dCIq9FpEcyQyXKCkyzmlPTFNgrCzPudOe+mhvJU5zAtlBnGVy2yKxtfsxK2tQBThwq225jcvBjpw1Gr40uzZCA==",
       "license": "ISC",
       "dependencies": {
@@ -3348,15 +3284,9 @@
         "node": ">=8.0.0"
       }
     },
-    "node_modules/sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-      "license": "BSD-3-Clause"
-    },
     "node_modules/string-width": {
       "version": "4.2.3",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/string-width/-/string-width-4.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "license": "MIT",
       "dependencies": {
@@ -3370,7 +3300,7 @@
     },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "license": "MIT",
       "dependencies": {
@@ -3382,7 +3312,7 @@
     },
     "node_modules/strip-bom": {
       "version": "4.0.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/strip-bom/-/strip-bom-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
       "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
       "license": "MIT",
       "engines": {
@@ -3391,7 +3321,7 @@
     },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true,
       "license": "MIT",
@@ -3404,7 +3334,7 @@
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/supports-color/-/supports-color-7.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "license": "MIT",
       "dependencies": {
@@ -3416,7 +3346,7 @@
     },
     "node_modules/test-exclude": {
       "version": "6.0.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/test-exclude/-/test-exclude-6.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
       "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
       "license": "ISC",
       "dependencies": {
@@ -3430,7 +3360,7 @@
     },
     "node_modules/test-exclude/node_modules/glob": {
       "version": "7.2.3",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/glob/-/glob-7.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
       "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "license": "ISC",
@@ -3451,14 +3381,14 @@
     },
     "node_modules/text-table": {
       "version": "0.2.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/text-table/-/text-table-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
       "dev": true,
       "license": "MIT",
@@ -3471,14 +3401,14 @@
     },
     "node_modules/tslib": {
       "version": "1.14.1",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/tslib/-/tslib-1.14.1.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "dev": true,
       "license": "0BSD"
     },
     "node_modules/tsutils": {
       "version": "3.21.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/tsutils/-/tsutils-3.21.0.tgz",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
       "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
       "dev": true,
       "license": "MIT",
@@ -3494,7 +3424,7 @@
     },
     "node_modules/type-check": {
       "version": "0.4.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/type-check/-/type-check-0.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
       "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
       "dev": true,
       "license": "MIT",
@@ -3507,7 +3437,7 @@
     },
     "node_modules/type-fest": {
       "version": "0.20.2",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/type-fest/-/type-fest-0.20.2.tgz",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
       "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
       "dev": true,
       "license": "(MIT OR CC0-1.0)",
@@ -3520,7 +3450,7 @@
     },
     "node_modules/typedarray-to-buffer": {
       "version": "3.1.5",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
       "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
       "license": "MIT",
       "dependencies": {
@@ -3529,7 +3459,7 @@
     },
     "node_modules/typescript": {
       "version": "5.9.3",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/typescript/-/typescript-5.9.3.tgz",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
@@ -3543,21 +3473,21 @@
     },
     "node_modules/typescript-logging": {
       "version": "2.2.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/typescript-logging/-/typescript-logging-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/typescript-logging/-/typescript-logging-2.2.0.tgz",
       "integrity": "sha512-mPKFGAgGJmeCqrzA6B64Lqoz6vLPtxa8yCd7sWAnfrz9opuNlxqW57VxjtEOL0OOoQeTdc/kBjGUh8sieBXa8A==",
       "license": "Apache-2.0"
     },
     "node_modules/undici-types": {
       "version": "6.21.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/undici-types/-/undici-types-6.21.0.tgz",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.2.3",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
-      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.1.tgz",
+      "integrity": "sha512-ZZ61DsRsOnakl74HAmp3oSN4aXUmEWXf+i/yv0h7tIBfICc3VdrFErQKUUKPgu3AMsTUMbcongALEN4l6GSUrQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -3586,7 +3516,7 @@
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/uri-js/-/uri-js-4.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -3596,7 +3526,7 @@
     },
     "node_modules/uuid": {
       "version": "8.3.2",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/uuid/-/uuid-8.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
       "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
       "license": "MIT",
@@ -3606,7 +3536,7 @@
     },
     "node_modules/vss-web-extension-sdk": {
       "version": "5.141.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/vss-web-extension-sdk/-/vss-web-extension-sdk-5.141.0.tgz",
+      "resolved": "https://registry.npmjs.org/vss-web-extension-sdk/-/vss-web-extension-sdk-5.141.0.tgz",
       "integrity": "sha512-c/r/HWQh4hljKOSNQMiFoeICckKFfU/1nxDCVFhioDHOE8B0i5aJN9rrihGilgMXugzl8K5hBsZs42eFqd30AQ==",
       "deprecated": "Package no longer supported. Please use https://www.npmjs.com/package/azure-devops-extension-sdk instead.",
       "license": "MIT",
@@ -3622,7 +3552,7 @@
     },
     "node_modules/which": {
       "version": "2.0.2",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/which/-/which-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
       "license": "ISC",
       "dependencies": {
@@ -3637,13 +3567,13 @@
     },
     "node_modules/which-module": {
       "version": "2.0.1",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/which-module/-/which-module-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
       "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
       "license": "ISC"
     },
     "node_modules/word-wrap": {
       "version": "1.2.5",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/word-wrap/-/word-wrap-1.2.5.tgz",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
       "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
       "dev": true,
       "license": "MIT",
@@ -3653,14 +3583,14 @@
     },
     "node_modules/workerpool": {
       "version": "6.5.1",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/workerpool/-/workerpool-6.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.5.1.tgz",
       "integrity": "sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==",
       "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "dev": true,
       "license": "MIT",
@@ -3678,13 +3608,13 @@
     },
     "node_modules/wrappy": {
       "version": "1.0.2",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/wrappy/-/wrappy-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
     },
     "node_modules/write-file-atomic": {
       "version": "3.0.3",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
       "integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
       "license": "ISC",
       "dependencies": {
@@ -3696,7 +3626,7 @@
     },
     "node_modules/y18n": {
       "version": "5.0.8",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/y18n/-/y18n-5.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
       "dev": true,
       "license": "ISC",
@@ -3706,14 +3636,14 @@
     },
     "node_modules/yallist": {
       "version": "3.1.1",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/yallist/-/yallist-3.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "license": "ISC"
     },
     "node_modules/yargs": {
-      "version": "16.2.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/yargs/-/yargs-16.2.0.tgz",
-      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "version": "16.2.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.2.tgz",
+      "integrity": "sha512-Nt9ZJjXTv5R8MHbqby/wXQ6Gi0Bb3TcYZkR1bzuL4yB2OxWPkXknz513gEF0GoA6tn00UpbPvERW8rzCuWCA6w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3731,7 +3661,7 @@
     },
     "node_modules/yargs-parser": {
       "version": "20.2.9",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
       "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
       "dev": true,
       "license": "ISC",
@@ -3741,7 +3671,7 @@
     },
     "node_modules/yargs-unparser": {
       "version": "2.0.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
       "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
       "dev": true,
       "license": "MIT",
@@ -3757,7 +3687,7 @@
     },
     "node_modules/yargs-unparser/node_modules/camelcase": {
       "version": "6.3.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/camelcase/-/camelcase-6.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
       "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
       "dev": true,
       "license": "MIT",
@@ -3770,7 +3700,7 @@
     },
     "node_modules/yargs-unparser/node_modules/decamelize": {
       "version": "4.0.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/decamelize/-/decamelize-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
       "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
       "dev": true,
       "license": "MIT",
@@ -3783,7 +3713,7 @@
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
-      "resolved": "https://packages.echohq.com/artifactory/api/npm/npm/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true,
       "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -33,8 +33,13 @@
   },
   "overrides": {
     "serialize-javascript": "^7.0.5",
-     "codecov": {
-      "js-yaml": "4.1.1"
+    "brace-expansion": "2.1.4",
+    "tar": "7.5.21",
+    "js-yaml": ">=3.15.1",
+    "browserslist": "4.28.7",
+    "adm-zip": "0.5.18",
+    "codecov": {
+      "js-yaml": "4.3.1"
     },
     "@humanwhocodes/config-array": {
       "minimatch": "3.1.4"

--- a/response_1787555948487.json
+++ b/response_1787555948487.json
@@ -1,0 +1,1257 @@
+{
+  "results": [
+    {
+      "type": "sca",
+      "id": "CVE-2026-13149",
+      "alternateId": "1zrM382Ivhtb4s7+qGEvwtBBvsKm9Fg8aZvCNfi3MOg=",
+      "similarityId": "CVE-2026-13149",
+      "status": "NEW",
+      "state": "TO_VERIFY",
+      "severity": "HIGH",
+      "confidenceLevel": 0,
+      "created": "2026-08-24T07:01:49Z",
+      "firstFoundAt": "2026-08-24T06:59:45Z",
+      "foundAt": "2026-08-24T07:01:49Z",
+      "firstScanId": "0c8fe820-b438-4614-95d3-dd7e3ffa2fe5",
+      "description": "brace-expansion through 5.0.6 is vulnerable to denial of service. The expand() function exhibits exponential-time complexity in the number of consecutive non-expanding '{}' brace groups. An attacker who passes a crafted string to expand(), directly or transitively, can cause significant CPU consumption and event-loop blocking. The max option does not mitigate this, as it bounds the output size rather than the recursion work.",
+      "data": {
+        "packageIdentifier": "Npm-brace-expansion-2.1.1",
+        "publishedAt": "2026-06-30T10:16:34+00:00",
+        "recommendations": "2.1.2",
+        "recommendedVersion": "2.1.2",
+        "exploitableMethods": null,
+        "packageData": [
+          {
+            "url": "https://github.com/advisories/GHSA-3jxr-9vmj-r5cp",
+            "type": "Advisory"
+          },
+          {
+            "url": "https://github.com/juliangruber/brace-expansion/commit/c7e33ec13ac1a684c116720843ce24e208611754",
+            "type": "Commit"
+          }
+        ]
+      },
+      "comments": {
+        "comments": ""
+      },
+      "vulnerabilityDetails": {
+        "cvssScore": 7.699999809265137,
+        "cveName": "CVE-2026-13149",
+        "cweId": "CWE-400",
+        "cvss": {
+          "score": 7.7,
+          "version": 4,
+          "severity": "High",
+          "attackVector": "NETWORK",
+          "userInteraction": "NONE",
+          "attackComplexity": "LOW",
+          "attackRequirements": "NONE",
+          "privilegesRequired": "NONE",
+          "subsequentSystemIntegrity": "NONE",
+          "vulnerableSystemIntegrity": "NONE",
+          "subsequentSystemAvailability": "NONE",
+          "vulnerableSystemAvailability": "HIGH",
+          "subsequentSystemConfidentiality": "NONE",
+          "vulnerableSystemConfidentiality": "NONE"
+        }
+      }
+    },
+    {
+      "type": "sca",
+      "id": "CVE-2026-14257",
+      "alternateId": "3r0XHL4JBsVg5nCI3HReYAAfLL8hzb8BxYyF060bc4Y=",
+      "similarityId": "CVE-2026-14257",
+      "status": "NEW",
+      "state": "TO_VERIFY",
+      "severity": "HIGH",
+      "confidenceLevel": 0,
+      "created": "2026-08-24T07:01:49Z",
+      "firstFoundAt": "2026-08-24T06:59:45Z",
+      "foundAt": "2026-08-24T07:01:49Z",
+      "firstScanId": "0c8fe820-b438-4614-95d3-dd7e3ffa2fe5",
+      "description": "brace-expansion through 5.0.7 is vulnerable to denial of service via memory exhaustion. The expand() function limits the number of results with a max option (default 100,000) but does not bound the length of each result string. By chaining multiple brace groups, an attacker keeps the result count under the limit while making each result progressively longer, so total memory scales with both count and string length until the process hits a fatal, uncatchable out-of-memory error. About 7.5 KB of input ('{a,b}'.repeat(1500)) crashes a default Node.js process. Any application that passes attacker-influenced strings to brace-expansion.expand() - directly or transitively via minimatch / glob brace patterns - can be crashed by a small request. Fixed in 5.0.8 by adding a maxLength option (default 4,000,000) that bounds accumulated output and intermediate arrays.",
+      "data": {
+        "packageIdentifier": "Npm-brace-expansion-2.1.1",
+        "publishedAt": "2026-07-23T14:17:00+00:00",
+        "recommendations": "2.1.3",
+        "recommendedVersion": "2.1.3",
+        "exploitableMethods": null,
+        "packageData": [
+          {
+            "url": "https://github.com/advisories/GHSA-mh99-v99m-4gvg",
+            "type": "Advisory"
+          },
+          {
+            "url": "https://github.com/juliangruber/brace-expansion/commit/a1bd33999ea75262c4749fff3bbb0d1372bd07b5",
+            "type": "Commit"
+          }
+        ]
+      },
+      "comments": {
+        "comments": ""
+      },
+      "vulnerabilityDetails": {
+        "cvssScore": 7.5,
+        "cveName": "CVE-2026-14257",
+        "cweId": "CWE-400",
+        "cvss": {
+          "scope": "UNCHANGED",
+          "score": 7.5,
+          "version": 3,
+          "severity": "High",
+          "integrity": "NONE",
+          "attackVector": "NETWORK",
+          "availability": "HIGH",
+          "confidentiality": "NONE",
+          "userInteraction": "NONE",
+          "attackComplexity": "LOW",
+          "privilegesRequired": "NONE"
+        }
+      }
+    },
+    {
+      "type": "sca",
+      "id": "CVE-2026-73088",
+      "alternateId": "6dxYwNO46fZbnCLsUBxMkcLuuhFA75QQeVBoYP0ugUc=",
+      "similarityId": "CVE-2026-73088",
+      "status": "NEW",
+      "state": "TO_VERIFY",
+      "severity": "HIGH",
+      "confidenceLevel": 0,
+      "created": "2026-08-24T07:01:49Z",
+      "firstFoundAt": "2026-08-24T06:59:45Z",
+      "foundAt": "2026-08-24T07:01:49Z",
+      "firstScanId": "0c8fe820-b438-4614-95d3-dd7e3ffa2fe5",
+      "description": "Browserslist is a configuration tool for sharing target browsers and Node.js versions between front-end tools. Prior to 4.28.7, \"normalizeStats()\" in node.js, reached unconditionally through \"getStat()\" and \"loadStat()\" on every \"browserslist()\" call, processes untrusted browserslist-stats.json, opts.stats, and CLI --stats data with an unguarded for...in loop and plain-object bracket access and assignment, allowing inherited Object.prototype keys including __proto__, toString, valueOf, constructor, hasOwnProperty, and isPrototypeOf to cause an uncaught TypeError or modify the prototype of the returned normalized object. This issue is fixed in version 4.28.7.",
+      "data": {
+        "packageIdentifier": "Npm-browserslist-4.28.2",
+        "publishedAt": "2026-08-11T17:19:16+00:00",
+        "recommendations": "4.28.7",
+        "recommendedVersion": "4.28.7",
+        "exploitableMethods": null,
+        "packageData": [
+          {
+            "url": "https://github.com/browserslist/browserslist/security/advisories/GHSA-73wf-gq98-2v4g",
+            "type": "Advisory"
+          },
+          {
+            "url": "https://github.com/browserslist/browserslist/commit/f9914ad9effc865ccc27d816255625890b31ca51",
+            "type": "Commit"
+          },
+          {
+            "url": "https://github.com/browserslist/browserslist/releases/tag/4.28.7",
+            "type": "Release Note"
+          }
+        ]
+      },
+      "comments": {
+        "comments": ""
+      },
+      "vulnerabilityDetails": {
+        "cvssScore": 7.5,
+        "cveName": "CVE-2026-73088",
+        "cweId": "CWE-248",
+        "cvss": {
+          "scope": "UNCHANGED",
+          "score": 7.5,
+          "version": 3,
+          "severity": "High",
+          "integrity": "NONE",
+          "attackVector": "NETWORK",
+          "availability": "HIGH",
+          "confidentiality": "NONE",
+          "userInteraction": "NONE",
+          "attackComplexity": "LOW",
+          "privilegesRequired": "NONE"
+        }
+      }
+    },
+    {
+      "type": "sca",
+      "id": "CVE-2026-73566",
+      "alternateId": "9DmZyL05IBQvSgCYm3jvtSz9PcFVxz/+goNYxHdvnTQ=",
+      "similarityId": "CVE-2026-73566",
+      "status": "NEW",
+      "state": "TO_VERIFY",
+      "severity": "HIGH",
+      "confidenceLevel": 0,
+      "created": "2026-08-24T07:01:49Z",
+      "firstFoundAt": "2026-08-24T06:59:45Z",
+      "foundAt": "2026-08-24T07:01:49Z",
+      "firstScanId": "0c8fe820-b438-4614-95d3-dd7e3ffa2fe5",
+      "description": "node-tar is a tar archive manipulation library for Node.js. Prior to version 7.5.21, node-tar's `filesFilter` in `src/list.ts` uses the recursive `mapHas` helper to walk an archive entry path upward with `path.dirname()` and no segment cap when `tar.t(...)` or `tar.x(...)` receives a non-empty member-selection list. A crafted GNU L or PAX x long-path header with thousands of slash-separated segments reaches `this.filter(entry.path, entry)` in `Parser[CONSUMEHEADER]` in `src/parse.ts` before `Unpack[CHECKPATH]` applies `maxDepth`, causing an uncatchable `RangeError` stack overflow that terminates asynchronous and streaming Node.js consumers. This issue is fixed in version 7.5.21.",
+      "data": {
+        "packageIdentifier": "Npm-tar-7.5.16",
+        "publishedAt": "2026-08-13T18:18:19+00:00",
+        "recommendations": "7.5.21",
+        "recommendedVersion": "7.5.21",
+        "exploitableMethods": null,
+        "packageData": [
+          {
+            "url": "https://github.com/advisories/GHSA-r292-9mhp-454m",
+            "type": "Advisory"
+          },
+          {
+            "url": "https://github.com/isaacs/node-tar/commit/631ae59121bf8fc8a22bbae35f074cb9b789cd4a",
+            "type": "Commit"
+          }
+        ]
+      },
+      "comments": {
+        "comments": ""
+      },
+      "vulnerabilityDetails": {
+        "cvssScore": 7.5,
+        "cveName": "CVE-2026-73566",
+        "cweId": "CWE-400",
+        "cvss": {
+          "scope": "UNCHANGED",
+          "score": 7.5,
+          "version": 3,
+          "severity": "High",
+          "integrity": "NONE",
+          "attackVector": "NETWORK",
+          "availability": "HIGH",
+          "confidentiality": "NONE",
+          "userInteraction": "NONE",
+          "attackComplexity": "LOW",
+          "privilegesRequired": "NONE"
+        }
+      }
+    },
+    {
+      "type": "sca",
+      "id": "CVE-2026-59869",
+      "alternateId": "cCF5ey9gX7r1sWcRm2bfRMCXRJbyDfsZ++w/PwGmwnA=",
+      "similarityId": "CVE-2026-59869",
+      "status": "NEW",
+      "state": "TO_VERIFY",
+      "severity": "HIGH",
+      "confidenceLevel": 0,
+      "created": "2026-08-24T07:01:49Z",
+      "firstFoundAt": "2026-08-24T06:59:45Z",
+      "foundAt": "2026-08-24T07:01:49Z",
+      "firstScanId": "0c8fe820-b438-4614-95d3-dd7e3ffa2fe5",
+      "description": "js-yaml is a JavaScript YAML parser and dumper. From 3.0.0 prior to 3.15.0 and from 4.0.0 prior to 4.3.0, from 5.0.0 prior to 5.1.0, js-yaml can spend quadratic CPU time parsing a document whose size grows only linearly when a chain of mappings uses merge keys where each mapping merges the previous one. This issue is fixed in versions 3.15.0 and 4.3.0.",
+      "data": {
+        "packageIdentifier": "Npm-js-yaml-4.2.0",
+        "publishedAt": "2026-07-08T16:16:33+00:00",
+        "recommendations": "4.3.0",
+        "recommendedVersion": "4.3.0",
+        "exploitableMethods": null,
+        "packageData": [
+          {
+            "url": "https://github.com/advisories/GHSA-52cp-r559-cp3m",
+            "type": "Advisory"
+          },
+          {
+            "url": "https://github.com/nodeca/js-yaml/security/advisories/GHSA-52cp-r559-cp3m",
+            "type": "Advisory"
+          },
+          {
+            "url": "https://github.com/nodeca/js-yaml/commit/3105455b81dee69e0fd36e09ac0b2ccfdb54adc1",
+            "type": "Commit"
+          }
+        ]
+      },
+      "comments": {
+        "comments": ""
+      },
+      "vulnerabilityDetails": {
+        "cvssScore": 7.5,
+        "cveName": "CVE-2026-59869",
+        "cweId": "CWE-407",
+        "cvss": {
+          "scope": "UNCHANGED",
+          "score": 7.5,
+          "version": 3,
+          "severity": "High",
+          "integrity": "NONE",
+          "attackVector": "NETWORK",
+          "availability": "HIGH",
+          "confidentiality": "NONE",
+          "userInteraction": "NONE",
+          "attackComplexity": "LOW",
+          "privilegesRequired": "NONE"
+        }
+      }
+    },
+    {
+      "type": "sca",
+      "id": "Cx0e1b35ca-f68b",
+      "alternateId": "d+1oquv+OEJMZZC3t+BkdrvQHY7pwC9nmYcNmlYSWCo=",
+      "similarityId": "Cx0e1b35ca-f68b",
+      "status": "NEW",
+      "state": "TO_VERIFY",
+      "severity": "HIGH",
+      "confidenceLevel": 0,
+      "created": "2026-08-24T07:01:49Z",
+      "firstFoundAt": "2026-08-24T06:59:45Z",
+      "foundAt": "2026-08-24T07:01:49Z",
+      "firstScanId": "0c8fe820-b438-4614-95d3-dd7e3ffa2fe5",
+      "description": "\"resolveYamlOmap()\" enforces key uniqueness for !!omap sequences with a linear\nscan (objectKeys.indexOf(...)) inside the per-element loop, making resolution\nO(n2) in the number of entries. A modestly sized YAML document therefore\nconsumes disproportionate CPU inside \"yaml.load()\", giving a denial of service\nagainst any consumer that parses untrusted YAML.!!omap is registered in the default schema\n(lib/schema/default.js - require('../type/omap')), so a plain\n\"yaml.load(untrustedInput)\" with no options is affected -- no custom schema or\nnon-default configuration is required. Versions 3.0.0 prior to 3.15.1 and 4.0.0 prior to 4.3.1 are affected.",
+      "data": {
+        "packageIdentifier": "Npm-js-yaml-3.14.2",
+        "publishedAt": "2026-08-06T12:00:00+00:00",
+        "recommendations": "3.15.1",
+        "recommendedVersion": "3.15.1",
+        "exploitableMethods": null,
+        "packageData": [
+          {
+            "url": "https://github.com/advisories/GHSA-5p4m-2wfm-xmqj",
+            "type": "Advisory"
+          }
+        ]
+      },
+      "comments": {
+        "comments": ""
+      },
+      "vulnerabilityDetails": {
+        "cvssScore": 7.5,
+        "cveName": "Cx0e1b35ca-f68b",
+        "cweId": "CWE-407",
+        "cvss": {
+          "scope": "UNCHANGED",
+          "score": 7.5,
+          "version": 3,
+          "severity": "High",
+          "integrity": "NONE",
+          "attackVector": "NETWORK",
+          "availability": "HIGH",
+          "confidentiality": "NONE",
+          "userInteraction": "NONE",
+          "attackComplexity": "LOW",
+          "privilegesRequired": "NONE"
+        }
+      }
+    },
+    {
+      "type": "sscs-secret-detection",
+      "id": "dA4KDJkrcCAr2Y9pRmBDI_eWvCGlcPHEcfoDhH0ejyQ",
+      "alternateId": "dA4KDJkrcCAr2Y9pRmBDI_eWvCGlcPHEcfoDhH0ejyQ",
+      "similarityId": "a281fe4af92551d82357f7a74b3500e79228a33ddf401a837815af8aaaf047d4",
+      "status": "NEW",
+      "state": "TO_VERIFY",
+      "severity": "MEDIUM",
+      "confidenceLevel": 0,
+      "created": "2026-08-24T06:59:46Z",
+      "firstFoundAt": "2026-08-24T06:59:46Z",
+      "foundAt": "2026-08-24T06:59:46Z",
+      "firstScanId": "0c8fe820-b438-4614-95d3-dd7e3ffa2fe5",
+      "description": "Hardcoded_Password has detected secret for file /.github/workflows/release.yml.",
+      "data": {
+        "ruleId": "cf670c62-6b61-4edf-913c-aff5a08bdf11",
+        "ruleName": "Hardcoded_Password",
+        "fileName": "/.github/workflows/release.yml",
+        "line": 210,
+        "snippet": "inhe***",
+        "slsaStep": "Source",
+        "ruleDescription": "test",
+        "remediation": "Remove secret inhe***  from source control and store it in your organization’s secret manager (e.g., AWS Secrets Manager, Azure Key Vault, HashiCorp Vault).",
+        "remediationLink": null,
+        "remediationAdditional": "Retrieve it at runtime through environment variables or the secret manager’s SDK. Make sure to rotate/revoke the exposed secret, and re-scan once fixed.",
+        "validity": "Unknown",
+        "isInSource": true,
+        "commitUrl": ""
+      },
+      "comments": {},
+      "vulnerabilityDetails": {}
+    },
+    {
+      "type": "sca",
+      "id": "CVE-2026-69152",
+      "alternateId": "dww+NWhaw4g+/0GAZZ/TVGbaIu8iBkx2BFamhyD8nMI=",
+      "similarityId": "CVE-2026-69152",
+      "status": "NEW",
+      "state": "TO_VERIFY",
+      "severity": "HIGH",
+      "confidenceLevel": 0,
+      "created": "2026-08-24T07:01:49Z",
+      "firstFoundAt": "2026-08-24T06:59:45Z",
+      "foundAt": "2026-08-24T07:01:49Z",
+      "firstScanId": "0c8fe820-b438-4614-95d3-dd7e3ffa2fe5",
+      "description": "The brace-expansion library generates arbitrary strings containing a common prefix and suffix. Prior to 1.1.18, 2.x prior to 2.1.4, 3.x prior to 3.0.6 and 4.x through 5.x prior to 5.0.9, `expand()` does not apply `maxLength` while constructing comma-alternative intermediate arrays or padded sequences, allowing attacker-controlled input to exhaust memory or block the event loop. The fix for CVE-2026-14257 is bypassed by the vulnerability. This issue is fixed in versions 1.1.18, 2.1.4, 3.0.6, and 5.0.9.",
+      "data": {
+        "packageIdentifier": "Npm-brace-expansion-2.1.1",
+        "publishedAt": "2026-08-03T17:16:45+00:00",
+        "recommendations": "2.1.4",
+        "recommendedVersion": "2.1.4",
+        "exploitableMethods": null,
+        "packageData": [
+          {
+            "url": "https://github.com/advisories/GHSA-rgw5-rvv9-x895",
+            "type": "Advisory"
+          },
+          {
+            "url": "https://github.com/juliangruber/brace-expansion/commit/688a99eeaab02627c2b89ba8ba4821fecfa659cf",
+            "type": "Commit"
+          }
+        ]
+      },
+      "comments": {
+        "comments": ""
+      },
+      "vulnerabilityDetails": {
+        "cvssScore": 7.5,
+        "cveName": "CVE-2026-69152",
+        "cweId": "CWE-400",
+        "cvss": {
+          "scope": "UNCHANGED",
+          "score": 7.5,
+          "version": 3,
+          "severity": "High",
+          "integrity": "NONE",
+          "attackVector": "NETWORK",
+          "availability": "HIGH",
+          "confidentiality": "NONE",
+          "userInteraction": "NONE",
+          "attackComplexity": "LOW",
+          "privilegesRequired": "NONE"
+        }
+      }
+    },
+    {
+      "type": "sscs-secret-detection",
+      "id": "GAKjJZ4ogygi6oHvkdegtR7tjCbbnF3ggmxQsWfpI9U",
+      "alternateId": "GAKjJZ4ogygi6oHvkdegtR7tjCbbnF3ggmxQsWfpI9U",
+      "similarityId": "70af4c6ed09f4d7fd500d6dac88a6adf33ee3efd1f5918d7cf2b7b9a9b6f71ab",
+      "status": "NEW",
+      "state": "TO_VERIFY",
+      "severity": "MEDIUM",
+      "confidenceLevel": 0,
+      "created": "2026-08-24T06:59:46Z",
+      "firstFoundAt": "2026-08-24T06:59:46Z",
+      "foundAt": "2026-08-24T06:59:46Z",
+      "firstScanId": "0c8fe820-b438-4614-95d3-dd7e3ffa2fe5",
+      "description": "Hardcoded_Password has detected secret for file /.github/workflows/issue-automation.yml.",
+      "data": {
+        "ruleId": "cf670c62-6b61-4edf-913c-aff5a08bdf11",
+        "ruleName": "Hardcoded_Password",
+        "fileName": "/.github/workflows/issue-automation.yml",
+        "line": 17,
+        "snippet": "inhe***",
+        "slsaStep": "Source",
+        "ruleDescription": "test",
+        "remediation": "Remove secret inhe***  from source control and store it in your organization’s secret manager (e.g., AWS Secrets Manager, Azure Key Vault, HashiCorp Vault).",
+        "remediationLink": null,
+        "remediationAdditional": "Retrieve it at runtime through environment variables or the secret manager’s SDK. Make sure to rotate/revoke the exposed secret, and re-scan once fixed.",
+        "validity": "Unknown",
+        "isInSource": true,
+        "commitUrl": ""
+      },
+      "comments": {},
+      "vulnerabilityDetails": {}
+    },
+    {
+      "type": "sca",
+      "id": "CVE-2026-69152",
+      "alternateId": "kpImgIokmKsk6C+/gPrxbsNdR7wIvAy+iPN3IRwqptk=",
+      "similarityId": "CVE-2026-69152",
+      "status": "NEW",
+      "state": "TO_VERIFY",
+      "severity": "HIGH",
+      "confidenceLevel": 0,
+      "created": "2026-08-24T07:01:49Z",
+      "firstFoundAt": "2026-08-24T06:59:45Z",
+      "foundAt": "2026-08-24T07:01:49Z",
+      "firstScanId": "0c8fe820-b438-4614-95d3-dd7e3ffa2fe5",
+      "description": "The brace-expansion library generates arbitrary strings containing a common prefix and suffix. Prior to 1.1.18, 2.x prior to 2.1.4, 3.x prior to 3.0.6 and 4.x through 5.x prior to 5.0.9, `expand()` does not apply `maxLength` while constructing comma-alternative intermediate arrays or padded sequences, allowing attacker-controlled input to exhaust memory or block the event loop. The fix for CVE-2026-14257 is bypassed by the vulnerability. This issue is fixed in versions 1.1.18, 2.1.4, 3.0.6, and 5.0.9.",
+      "data": {
+        "packageIdentifier": "Npm-brace-expansion-1.1.15",
+        "publishedAt": "2026-08-03T17:16:45+00:00",
+        "recommendations": "1.1.18",
+        "recommendedVersion": "1.1.18",
+        "exploitableMethods": null,
+        "packageData": [
+          {
+            "url": "https://github.com/advisories/GHSA-rgw5-rvv9-x895",
+            "type": "Advisory"
+          },
+          {
+            "url": "https://github.com/juliangruber/brace-expansion/commit/688a99eeaab02627c2b89ba8ba4821fecfa659cf",
+            "type": "Commit"
+          }
+        ]
+      },
+      "comments": {
+        "comments": ""
+      },
+      "vulnerabilityDetails": {
+        "cvssScore": 7.5,
+        "cveName": "CVE-2026-69152",
+        "cweId": "CWE-400",
+        "cvss": {
+          "scope": "UNCHANGED",
+          "score": 7.5,
+          "version": 3,
+          "severity": "High",
+          "integrity": "NONE",
+          "attackVector": "NETWORK",
+          "availability": "HIGH",
+          "confidentiality": "NONE",
+          "userInteraction": "NONE",
+          "attackComplexity": "LOW",
+          "privilegesRequired": "NONE"
+        }
+      }
+    },
+    {
+      "type": "sscs-secret-detection",
+      "id": "npHy7LyonhREikc_7E7Zx9uXUaZh_u0eQXjVD5OPexM",
+      "alternateId": "npHy7LyonhREikc_7E7Zx9uXUaZh_u0eQXjVD5OPexM",
+      "similarityId": "52af35aadd0abe5b9f8206ce7925d227f06aa6d8b3035fc46e83fb2391223414",
+      "status": "NEW",
+      "state": "TO_VERIFY",
+      "severity": "MEDIUM",
+      "confidenceLevel": 0,
+      "created": "2026-08-24T06:59:46Z",
+      "firstFoundAt": "2026-08-24T06:59:46Z",
+      "foundAt": "2026-08-24T06:59:46Z",
+      "firstScanId": "0c8fe820-b438-4614-95d3-dd7e3ffa2fe5",
+      "description": "Hardcoded_Password has detected secret for file /.github/workflows/release.yml.",
+      "data": {
+        "ruleId": "cf670c62-6b61-4edf-913c-aff5a08bdf11",
+        "ruleName": "Hardcoded_Password",
+        "fileName": "/.github/workflows/release.yml",
+        "line": 207,
+        "snippet": "Phoe***",
+        "slsaStep": "Source",
+        "ruleDescription": "test",
+        "remediation": "Remove secret Phoe***  from source control and store it in your organization’s secret manager (e.g., AWS Secrets Manager, Azure Key Vault, HashiCorp Vault).",
+        "remediationLink": null,
+        "remediationAdditional": "Retrieve it at runtime through environment variables or the secret manager’s SDK. Make sure to rotate/revoke the exposed secret, and re-scan once fixed.",
+        "validity": "Unknown",
+        "isInSource": true,
+        "commitUrl": ""
+      },
+      "comments": {},
+      "vulnerabilityDetails": {}
+    },
+    {
+      "type": "sca",
+      "id": "CVE-2026-39244",
+      "alternateId": "oGgb8q1ovNlXy4RzKAcqRwn5+/CQeK14GesD3V2JSfI=",
+      "similarityId": "CVE-2026-39244",
+      "status": "NEW",
+      "state": "TO_VERIFY",
+      "severity": "HIGH",
+      "confidenceLevel": 0,
+      "created": "2026-08-24T07:01:49Z",
+      "firstFoundAt": "2026-08-24T06:59:45Z",
+      "foundAt": "2026-08-24T07:01:49Z",
+      "firstScanId": "0c8fe820-b438-4614-95d3-dd7e3ffa2fe5",
+      "description": "adm-zip before 0.5.18 is vulnerable to denial of service via a crafted ZIP file with a manipulated uncompressed size header field. In zipEntry.js line 103, Buffer.alloc(_centralHeader.size) allocates memory based on the declared uncompressed size from the ZIP central directory header without validating it against the actual compressed data size or imposing any upper bound. The size value is read directly from the binary header at entryHeader.js line 266 with no bounds check. An attacker can craft a ~120-byte ZIP file that declares ~4GB uncompressed size, causing a memory allocation amplification ratio of over 33 million to 1. The allocation occurs before CRC validation, so the malicious payload cannot be rejected early. All extraction and read methods are affected: readFile(), readAsText(), extractEntryTo(), extractAllTo(), extractAllToAsync(), test(), and entry.getData(). Any application accepting untrusted ZIP files via adm-zip is vulnerable to immediate process crash.",
+      "data": {
+        "packageIdentifier": "Npm-adm-zip-0.5.17",
+        "publishedAt": "2026-07-10T17:16:57+00:00",
+        "recommendations": "0.5.18",
+        "recommendedVersion": "0.5.18",
+        "exploitableMethods": null,
+        "packageData": [
+          {
+            "url": "https://github.com/advisories/GHSA-xcpc-8h2w-3j85",
+            "type": "Advisory"
+          }
+        ]
+      },
+      "comments": {
+        "comments": ""
+      },
+      "vulnerabilityDetails": {
+        "cvssScore": 7.5,
+        "cveName": "CVE-2026-39244",
+        "cweId": "CWE-400",
+        "cvss": {
+          "scope": "UNCHANGED",
+          "score": 7.5,
+          "version": 3,
+          "severity": "High",
+          "integrity": "NONE",
+          "attackVector": "NETWORK",
+          "availability": "HIGH",
+          "confidentiality": "NONE",
+          "userInteraction": "NONE",
+          "attackComplexity": "LOW",
+          "privilegesRequired": "NONE"
+        }
+      }
+    },
+    {
+      "type": "sca",
+      "id": "CVE-2026-73089",
+      "alternateId": "onis+a/lovRcVeIkwARxJROIek1q0CBJVu0Rf/wGYl0=",
+      "similarityId": "CVE-2026-73089",
+      "status": "NEW",
+      "state": "TO_VERIFY",
+      "severity": "HIGH",
+      "confidenceLevel": 0,
+      "created": "2026-08-24T07:01:49Z",
+      "firstFoundAt": "2026-08-24T06:59:45Z",
+      "foundAt": "2026-08-24T07:01:49Z",
+      "firstScanId": "0c8fe820-b438-4614-95d3-dd7e3ffa2fe5",
+      "description": "Browserslist is a configuration tool for sharing target browsers and Node.js versions between front-end tools. Prior to 4.28.7, index.js retains every distinct `(queries, context)` result in cache and every \"parseQueries()\" AST in parseCache without a size cap, TTL, or eviction, allowing an attacker who can influence repeated browserslist() query values, including valid since `<year>-<month>-<day>` queries, to bypass the caller-controlled BROWSERSLIST_DISABLE_CACHE mitigation and cause linear memory growth followed by an out-of-memory process crash. This issue is fixed in version 4.28.7.",
+      "data": {
+        "packageIdentifier": "Npm-browserslist-4.28.2",
+        "publishedAt": "2026-08-11T17:19:17+00:00",
+        "recommendations": "4.28.7",
+        "recommendedVersion": "4.28.7",
+        "exploitableMethods": null,
+        "packageData": [
+          {
+            "url": "https://github.com/browserslist/browserslist/security/advisories/GHSA-c83g-rgw3-j3cx",
+            "type": "Advisory"
+          },
+          {
+            "url": "https://github.com/browserslist/browserslist/commit/f2931a3ff2a3a31abf84ef01a7400b270aad6405",
+            "type": "Commit"
+          },
+          {
+            "url": "https://github.com/browserslist/browserslist/releases/tag/4.28.7",
+            "type": "Release Note"
+          }
+        ]
+      },
+      "comments": {
+        "comments": ""
+      },
+      "vulnerabilityDetails": {
+        "cvssScore": 7.5,
+        "cveName": "CVE-2026-73089",
+        "cweId": "CWE-770",
+        "cvss": {
+          "scope": "UNCHANGED",
+          "score": 7.5,
+          "version": 3,
+          "severity": "High",
+          "integrity": "NONE",
+          "attackVector": "NETWORK",
+          "availability": "HIGH",
+          "confidentiality": "NONE",
+          "userInteraction": "NONE",
+          "attackComplexity": "LOW",
+          "privilegesRequired": "NONE"
+        }
+      }
+    },
+    {
+      "type": "sca",
+      "id": "Cxdca8e59f-8bfe",
+      "alternateId": "oPKiNanQfmdE8jptWJLBx1EksjCCXLCDNzz0mp2x4nE=",
+      "similarityId": "Cxdca8e59f-8bfe",
+      "status": "NEW",
+      "state": "NOT_EXPLOITABLE",
+      "severity": "HIGH",
+      "confidenceLevel": 0,
+      "created": "2026-08-24T07:01:49Z",
+      "firstFoundAt": "2026-08-24T06:59:45Z",
+      "foundAt": "2026-08-24T07:01:49Z",
+      "firstScanId": "0c8fe820-b438-4614-95d3-dd7e3ffa2fe5",
+      "description": "In NPM `inflight` there is a Memory Leak because some resources are not freed correctly after being used. It appears to affect all versions, as the issue was not addressed and no fix is found. NOTE: In the meantime, `logdna-agent`, a package that depends on `inflight`, has merged a commit to address this solely in their package (so it should be fixed in `logdna-agent` in versions 1.6.5 and later). `Node-glob`, a package that also depends on `inflight`, was also planning to address this by not using `inflight` after version 8 is released, but it is still being used.",
+      "data": {
+        "packageIdentifier": "Npm-inflight-1.0.6",
+        "publishedAt": "2020-12-07T10:10:00+00:00",
+        "recommendations": "",
+        "recommendedVersion": "",
+        "exploitableMethods": null,
+        "packageData": [
+          {
+            "url": "https://github.com/npm/inflight/issues/5",
+            "type": "Issue"
+          }
+        ]
+      },
+      "comments": {
+        "comments": ""
+      },
+      "vulnerabilityDetails": {
+        "cvssScore": 7.5,
+        "cveName": "Cxdca8e59f-8bfe",
+        "cweId": "CWE-772",
+        "cvss": {
+          "scope": "UNCHANGED",
+          "score": 7.5,
+          "version": 3,
+          "severity": "High",
+          "integrity": "NONE",
+          "attackVector": "NETWORK",
+          "availability": "HIGH",
+          "confidentiality": "NONE",
+          "userInteraction": "NONE",
+          "attackComplexity": "LOW",
+          "privilegesRequired": "NONE"
+        }
+      }
+    },
+    {
+      "type": "sca",
+      "id": "CVE-2026-59871",
+      "alternateId": "Ott96MjYRqL7G6SsdvtgHxa6XIBqZK84ZIwjLPzg0fk=",
+      "similarityId": "CVE-2026-59871",
+      "status": "NEW",
+      "state": "TO_VERIFY",
+      "severity": "HIGH",
+      "confidenceLevel": 0,
+      "created": "2026-08-24T07:01:49Z",
+      "firstFoundAt": "2026-08-24T06:59:45Z",
+      "foundAt": "2026-08-24T07:01:49Z",
+      "firstScanId": "0c8fe820-b438-4614-95d3-dd7e3ffa2fe5",
+      "description": "node-tar is a tar archive manipulation library for Node.js. Prior to 7.5.18, node-tar coerces all-digit PAX path and linkpath values in src/pax.ts to JavaScript numbers, causing downstream path handling such as normalizeWindowsPath(entry.path).split('/') to throw an uncaught TypeError. This issue is fixed in version 7.5.18.",
+      "data": {
+        "packageIdentifier": "Npm-tar-7.5.16",
+        "publishedAt": "2026-07-08T16:16:33+00:00",
+        "recommendations": "7.5.18",
+        "recommendedVersion": "7.5.18",
+        "exploitableMethods": null,
+        "packageData": [
+          {
+            "url": "https://github.com/advisories/GHSA-w8wr-v893-vjvp",
+            "type": "Advisory"
+          },
+          {
+            "url": "https://github.com/isaacs/node-tar/security/advisories/GHSA-w8wr-v893-vjvp",
+            "type": "Advisory"
+          },
+          {
+            "url": "https://github.com/isaacs/node-tar/commit/e02a4e9e013c4be95302e2eb2047a942b883c27b",
+            "type": "Commit"
+          },
+          {
+            "url": "https://github.com/isaacs/node-tar/releases/tag/v7.5.18",
+            "type": "Release Note"
+          }
+        ]
+      },
+      "comments": {
+        "comments": ""
+      },
+      "vulnerabilityDetails": {
+        "cvssScore": 7.5,
+        "cveName": "CVE-2026-59871",
+        "cweId": "CWE-704",
+        "cvss": {
+          "scope": "UNCHANGED",
+          "score": 7.5,
+          "version": 3,
+          "severity": "High",
+          "integrity": "NONE",
+          "attackVector": "NETWORK",
+          "availability": "HIGH",
+          "confidentiality": "NONE",
+          "userInteraction": "NONE",
+          "attackComplexity": "LOW",
+          "privilegesRequired": "NONE"
+        }
+      }
+    },
+    {
+      "type": "sca",
+      "id": "CVE-2026-59875",
+      "alternateId": "OwyPxdEVdrNR62MkJRUfpPzP0Ann9quT/Wa1HXpk3us=",
+      "similarityId": "CVE-2026-59875",
+      "status": "NEW",
+      "state": "TO_VERIFY",
+      "severity": "MEDIUM",
+      "confidenceLevel": 0,
+      "created": "2026-08-24T07:01:49Z",
+      "firstFoundAt": "2026-08-24T06:59:45Z",
+      "foundAt": "2026-08-24T07:01:49Z",
+      "firstScanId": "0c8fe820-b438-4614-95d3-dd7e3ffa2fe5",
+      "description": "node-tar is a tar archive manipulation library for Node.js. Prior to 7.5.17, node-tar does not strip NUL bytes from PAX path and linkpath records in src/pax.ts, allowing a crafted archive with values to reach fs.lstat or fs.open and terminate the process with an uncaught exception. This issue is fixed in version 7.5.17.",
+      "data": {
+        "packageIdentifier": "Npm-tar-7.5.16",
+        "publishedAt": "2026-07-08T16:16:34+00:00",
+        "recommendations": "7.5.17",
+        "recommendedVersion": "7.5.17",
+        "exploitableMethods": null,
+        "packageData": [
+          {
+            "url": "https://github.com/advisories/GHSA-gvwx-54wh-qm9j",
+            "type": "Advisory"
+          },
+          {
+            "url": "https://github.com/isaacs/node-tar/security/advisories/GHSA-gvwx-54wh-qm9j",
+            "type": "Advisory"
+          },
+          {
+            "url": "https://github.com/isaacs/node-tar/commit/7a635c29f5edbf083557374d43984273ecfed5b3",
+            "type": "Commit"
+          },
+          {
+            "url": "https://github.com/isaacs/node-tar/releases/tag/v7.5.17",
+            "type": "Release Note"
+          }
+        ]
+      },
+      "comments": {
+        "comments": ""
+      },
+      "vulnerabilityDetails": {
+        "cvssScore": 5.300000190734863,
+        "cveName": "CVE-2026-59875",
+        "cweId": "CWE-248",
+        "cvss": {
+          "scope": "UNCHANGED",
+          "score": 5.3,
+          "version": 3,
+          "severity": "Medium",
+          "integrity": "NONE",
+          "attackVector": "NETWORK",
+          "availability": "LOW",
+          "confidentiality": "NONE",
+          "userInteraction": "NONE",
+          "attackComplexity": "LOW",
+          "privilegesRequired": "NONE"
+        }
+      }
+    },
+    {
+      "type": "sca",
+      "id": "CVE-2026-13149",
+      "alternateId": "rDim7QVRyNSIDiYZZ+MyMP5g/DXtEcK/bTtQ2Q794Z4=",
+      "similarityId": "CVE-2026-13149",
+      "status": "NEW",
+      "state": "TO_VERIFY",
+      "severity": "HIGH",
+      "confidenceLevel": 0,
+      "created": "2026-08-24T07:01:49Z",
+      "firstFoundAt": "2026-08-24T06:59:45Z",
+      "foundAt": "2026-08-24T07:01:49Z",
+      "firstScanId": "0c8fe820-b438-4614-95d3-dd7e3ffa2fe5",
+      "description": "brace-expansion through 5.0.6 is vulnerable to denial of service. The expand() function exhibits exponential-time complexity in the number of consecutive non-expanding '{}' brace groups. An attacker who passes a crafted string to expand(), directly or transitively, can cause significant CPU consumption and event-loop blocking. The max option does not mitigate this, as it bounds the output size rather than the recursion work.",
+      "data": {
+        "packageIdentifier": "Npm-brace-expansion-1.1.15",
+        "publishedAt": "2026-06-30T10:16:34+00:00",
+        "recommendations": "1.1.16",
+        "recommendedVersion": "1.1.16",
+        "exploitableMethods": null,
+        "packageData": [
+          {
+            "url": "https://github.com/advisories/GHSA-3jxr-9vmj-r5cp",
+            "type": "Advisory"
+          },
+          {
+            "url": "https://github.com/juliangruber/brace-expansion/commit/c7e33ec13ac1a684c116720843ce24e208611754",
+            "type": "Commit"
+          }
+        ]
+      },
+      "comments": {
+        "comments": ""
+      },
+      "vulnerabilityDetails": {
+        "cvssScore": 7.699999809265137,
+        "cveName": "CVE-2026-13149",
+        "cweId": "CWE-400",
+        "cvss": {
+          "score": 7.7,
+          "version": 4,
+          "severity": "High",
+          "attackVector": "NETWORK",
+          "userInteraction": "NONE",
+          "attackComplexity": "LOW",
+          "attackRequirements": "NONE",
+          "privilegesRequired": "NONE",
+          "subsequentSystemIntegrity": "NONE",
+          "vulnerableSystemIntegrity": "NONE",
+          "subsequentSystemAvailability": "NONE",
+          "vulnerableSystemAvailability": "HIGH",
+          "subsequentSystemConfidentiality": "NONE",
+          "vulnerableSystemConfidentiality": "NONE"
+        }
+      }
+    },
+    {
+      "type": "sca",
+      "id": "CVE-2026-59874",
+      "alternateId": "TdiYKMuqaL2xJKWgBSkEApSsb3r3EELNPGrmpslTwAw=",
+      "similarityId": "CVE-2026-59874",
+      "status": "NEW",
+      "state": "TO_VERIFY",
+      "severity": "HIGH",
+      "confidenceLevel": 0,
+      "created": "2026-08-24T07:01:49Z",
+      "firstFoundAt": "2026-08-24T06:59:45Z",
+      "foundAt": "2026-08-24T07:01:49Z",
+      "firstScanId": "0c8fe820-b438-4614-95d3-dd7e3ffa2fe5",
+      "description": "node-tar is a tar archive manipulation library for Node.js. Prior to 7.5.18, tar.replace accepts a checksum-valid tar header with a negative base-256 encoded entry size, causing the archive scanner to make no progress while repeatedly parsing the same header. This issue is fixed in version 7.5.18.",
+      "data": {
+        "packageIdentifier": "Npm-tar-7.5.16",
+        "publishedAt": "2026-07-08T16:16:33+00:00",
+        "recommendations": "7.5.18",
+        "recommendedVersion": "7.5.18",
+        "exploitableMethods": null,
+        "packageData": [
+          {
+            "url": "https://github.com/advisories/GHSA-8x88-c5mf-7j5w",
+            "type": "Advisory"
+          },
+          {
+            "url": "https://github.com/isaacs/node-tar/security/advisories/GHSA-8x88-c5mf-7j5w",
+            "type": "Advisory"
+          },
+          {
+            "url": "https://github.com/isaacs/node-tar/commit/9e78bf058b2c22dd4d52e00d8922d5c06fc2f7b5",
+            "type": "Commit"
+          }
+        ]
+      },
+      "comments": {
+        "comments": ""
+      },
+      "vulnerabilityDetails": {
+        "cvssScore": 8.699999809265137,
+        "cveName": "CVE-2026-59874",
+        "cweId": "CWE-835",
+        "cvss": {
+          "score": 8.7,
+          "version": 4,
+          "severity": "High",
+          "attackVector": "NETWORK",
+          "userInteraction": "NONE",
+          "attackComplexity": "LOW",
+          "attackRequirements": "NONE",
+          "privilegesRequired": "NONE",
+          "subsequentSystemIntegrity": "NONE",
+          "vulnerableSystemIntegrity": "NONE",
+          "subsequentSystemAvailability": "NONE",
+          "vulnerableSystemAvailability": "HIGH",
+          "subsequentSystemConfidentiality": "NONE",
+          "vulnerableSystemConfidentiality": "NONE"
+        }
+      }
+    },
+    {
+      "type": "sscs-secret-detection",
+      "id": "U-jwkGVCsvtjA_a8ma01m_PT01Akb8UJ8NEhErjKW6w",
+      "alternateId": "U-jwkGVCsvtjA_a8ma01m_PT01Akb8UJ8NEhErjKW6w",
+      "similarityId": "f06e5315596db16f3a89b1d71db3748ff1e2be181de71ce7548a9502b55de75a",
+      "status": "NEW",
+      "state": "TO_VERIFY",
+      "severity": "MEDIUM",
+      "confidenceLevel": 0,
+      "created": "2026-08-24T06:59:46Z",
+      "firstFoundAt": "2026-08-24T06:59:46Z",
+      "foundAt": "2026-08-24T06:59:46Z",
+      "firstScanId": "0c8fe820-b438-4614-95d3-dd7e3ffa2fe5",
+      "description": "Hardcoded_Password has detected secret for file /cxAstScan/services/Utils.ts.",
+      "data": {
+        "ruleId": "cf670c62-6b61-4edf-913c-aff5a08bdf11",
+        "ruleName": "Hardcoded_Password",
+        "fileName": "/cxAstScan/services/Utils.ts",
+        "line": 49,
+        "snippet": "apiK***",
+        "slsaStep": "Source",
+        "ruleDescription": "test",
+        "remediation": "Remove secret apiK***  from source control and store it in your organization’s secret manager (e.g., AWS Secrets Manager, Azure Key Vault, HashiCorp Vault).",
+        "remediationLink": null,
+        "remediationAdditional": "Retrieve it at runtime through environment variables or the secret manager’s SDK. Make sure to rotate/revoke the exposed secret, and re-scan once fixed.",
+        "validity": "Unknown",
+        "isInSource": true,
+        "commitUrl": ""
+      },
+      "comments": {},
+      "vulnerabilityDetails": {}
+    },
+    {
+      "type": "sca",
+      "id": "CVE-2026-14257",
+      "alternateId": "VpFXzFvl1wX0eKLRUNUN3+VKNAukskQ3Bj0aEuilzLQ=",
+      "similarityId": "CVE-2026-14257",
+      "status": "NEW",
+      "state": "TO_VERIFY",
+      "severity": "HIGH",
+      "confidenceLevel": 0,
+      "created": "2026-08-24T07:01:49Z",
+      "firstFoundAt": "2026-08-24T06:59:45Z",
+      "foundAt": "2026-08-24T07:01:49Z",
+      "firstScanId": "0c8fe820-b438-4614-95d3-dd7e3ffa2fe5",
+      "description": "brace-expansion through 5.0.7 is vulnerable to denial of service via memory exhaustion. The expand() function limits the number of results with a max option (default 100,000) but does not bound the length of each result string. By chaining multiple brace groups, an attacker keeps the result count under the limit while making each result progressively longer, so total memory scales with both count and string length until the process hits a fatal, uncatchable out-of-memory error. About 7.5 KB of input ('{a,b}'.repeat(1500)) crashes a default Node.js process. Any application that passes attacker-influenced strings to brace-expansion.expand() - directly or transitively via minimatch / glob brace patterns - can be crashed by a small request. Fixed in 5.0.8 by adding a maxLength option (default 4,000,000) that bounds accumulated output and intermediate arrays.",
+      "data": {
+        "packageIdentifier": "Npm-brace-expansion-1.1.15",
+        "publishedAt": "2026-07-23T14:17:00+00:00",
+        "recommendations": "1.1.17",
+        "recommendedVersion": "1.1.17",
+        "exploitableMethods": null,
+        "packageData": [
+          {
+            "url": "https://github.com/advisories/GHSA-mh99-v99m-4gvg",
+            "type": "Advisory"
+          },
+          {
+            "url": "https://github.com/juliangruber/brace-expansion/commit/a1bd33999ea75262c4749fff3bbb0d1372bd07b5",
+            "type": "Commit"
+          }
+        ]
+      },
+      "comments": {
+        "comments": ""
+      },
+      "vulnerabilityDetails": {
+        "cvssScore": 7.5,
+        "cveName": "CVE-2026-14257",
+        "cweId": "CWE-400",
+        "cvss": {
+          "scope": "UNCHANGED",
+          "score": 7.5,
+          "version": 3,
+          "severity": "High",
+          "integrity": "NONE",
+          "attackVector": "NETWORK",
+          "availability": "HIGH",
+          "confidentiality": "NONE",
+          "userInteraction": "NONE",
+          "attackComplexity": "LOW",
+          "privilegesRequired": "NONE"
+        }
+      }
+    },
+    {
+      "type": "sca",
+      "id": "CVE-2026-59869",
+      "alternateId": "wvKd3IXeRMvgln1CNdR2qzmyKtOBbr3i8KfE2s5xfGM=",
+      "similarityId": "CVE-2026-59869",
+      "status": "NEW",
+      "state": "TO_VERIFY",
+      "severity": "HIGH",
+      "confidenceLevel": 0,
+      "created": "2026-08-24T07:01:49Z",
+      "firstFoundAt": "2026-08-24T06:59:45Z",
+      "foundAt": "2026-08-24T07:01:49Z",
+      "firstScanId": "0c8fe820-b438-4614-95d3-dd7e3ffa2fe5",
+      "description": "js-yaml is a JavaScript YAML parser and dumper. From 3.0.0 prior to 3.15.0 and from 4.0.0 prior to 4.3.0, from 5.0.0 prior to 5.1.0, js-yaml can spend quadratic CPU time parsing a document whose size grows only linearly when a chain of mappings uses merge keys where each mapping merges the previous one. This issue is fixed in versions 3.15.0 and 4.3.0.",
+      "data": {
+        "packageIdentifier": "Npm-js-yaml-3.14.2",
+        "publishedAt": "2026-07-08T16:16:33+00:00",
+        "recommendations": "3.15.0",
+        "recommendedVersion": "3.15.0",
+        "exploitableMethods": null,
+        "packageData": [
+          {
+            "url": "https://github.com/advisories/GHSA-52cp-r559-cp3m",
+            "type": "Advisory"
+          },
+          {
+            "url": "https://github.com/nodeca/js-yaml/security/advisories/GHSA-52cp-r559-cp3m",
+            "type": "Advisory"
+          },
+          {
+            "url": "https://github.com/nodeca/js-yaml/commit/3105455b81dee69e0fd36e09ac0b2ccfdb54adc1",
+            "type": "Commit"
+          }
+        ]
+      },
+      "comments": {
+        "comments": ""
+      },
+      "vulnerabilityDetails": {
+        "cvssScore": 7.5,
+        "cveName": "CVE-2026-59869",
+        "cweId": "CWE-407",
+        "cvss": {
+          "scope": "UNCHANGED",
+          "score": 7.5,
+          "version": 3,
+          "severity": "High",
+          "integrity": "NONE",
+          "attackVector": "NETWORK",
+          "availability": "HIGH",
+          "confidentiality": "NONE",
+          "userInteraction": "NONE",
+          "attackComplexity": "LOW",
+          "privilegesRequired": "NONE"
+        }
+      }
+    },
+    {
+      "type": "sscs-secret-detection",
+      "id": "Y84FPCaZ4_nCCs0FhW4QZhzwj7adQArQPzWabE67Sbg",
+      "alternateId": "Y84FPCaZ4_nCCs0FhW4QZhzwj7adQArQPzWabE67Sbg",
+      "similarityId": "70af4c6ed09f4d7fd500d6dac88a6adf33ee3efd1f5918d7cf2b7b9a9b6f71ab",
+      "status": "NEW",
+      "state": "TO_VERIFY",
+      "severity": "MEDIUM",
+      "confidenceLevel": 0,
+      "created": "2026-08-24T06:59:46Z",
+      "firstFoundAt": "2026-08-24T06:59:46Z",
+      "foundAt": "2026-08-24T06:59:46Z",
+      "firstScanId": "0c8fe820-b438-4614-95d3-dd7e3ffa2fe5",
+      "description": "Hardcoded_Password has detected secret for file /.github/workflows/issue-automation.yml.",
+      "data": {
+        "ruleId": "cf670c62-6b61-4edf-913c-aff5a08bdf11",
+        "ruleName": "Hardcoded_Password",
+        "fileName": "/.github/workflows/issue-automation.yml",
+        "line": 26,
+        "snippet": "inhe***",
+        "slsaStep": "Source",
+        "ruleDescription": "test",
+        "remediation": "Remove secret inhe***  from source control and store it in your organization’s secret manager (e.g., AWS Secrets Manager, Azure Key Vault, HashiCorp Vault).",
+        "remediationLink": null,
+        "remediationAdditional": "Retrieve it at runtime through environment variables or the secret manager’s SDK. Make sure to rotate/revoke the exposed secret, and re-scan once fixed.",
+        "validity": "Unknown",
+        "isInSource": true,
+        "commitUrl": ""
+      },
+      "comments": {},
+      "vulnerabilityDetails": {}
+    },
+    {
+      "type": "sca",
+      "id": "Cx0e1b35ca-f68b",
+      "alternateId": "yhZZXDd5nG4zT4MX1pR0jeCcuh4r7mFzRGpVRPGg9nE=",
+      "similarityId": "Cx0e1b35ca-f68b",
+      "status": "NEW",
+      "state": "TO_VERIFY",
+      "severity": "HIGH",
+      "confidenceLevel": 0,
+      "created": "2026-08-24T07:01:49Z",
+      "firstFoundAt": "2026-08-24T06:59:45Z",
+      "foundAt": "2026-08-24T07:01:49Z",
+      "firstScanId": "0c8fe820-b438-4614-95d3-dd7e3ffa2fe5",
+      "description": "\"resolveYamlOmap()\" enforces key uniqueness for !!omap sequences with a linear\nscan (objectKeys.indexOf(...)) inside the per-element loop, making resolution\nO(n2) in the number of entries. A modestly sized YAML document therefore\nconsumes disproportionate CPU inside \"yaml.load()\", giving a denial of service\nagainst any consumer that parses untrusted YAML.!!omap is registered in the default schema\n(lib/schema/default.js - require('../type/omap')), so a plain\n\"yaml.load(untrustedInput)\" with no options is affected -- no custom schema or\nnon-default configuration is required. Versions 3.0.0 prior to 3.15.1 and 4.0.0 prior to 4.3.1 are affected.",
+      "data": {
+        "packageIdentifier": "Npm-js-yaml-4.2.0",
+        "publishedAt": "2026-08-06T12:00:00+00:00",
+        "recommendations": "4.3.1",
+        "recommendedVersion": "4.3.1",
+        "exploitableMethods": null,
+        "packageData": [
+          {
+            "url": "https://github.com/advisories/GHSA-5p4m-2wfm-xmqj",
+            "type": "Advisory"
+          }
+        ]
+      },
+      "comments": {
+        "comments": ""
+      },
+      "vulnerabilityDetails": {
+        "cvssScore": 7.5,
+        "cveName": "Cx0e1b35ca-f68b",
+        "cweId": "CWE-407",
+        "cvss": {
+          "scope": "UNCHANGED",
+          "score": 7.5,
+          "version": 3,
+          "severity": "High",
+          "integrity": "NONE",
+          "attackVector": "NETWORK",
+          "availability": "HIGH",
+          "confidentiality": "NONE",
+          "userInteraction": "NONE",
+          "attackComplexity": "LOW",
+          "privilegesRequired": "NONE"
+        }
+      }
+    },
+    {
+      "type": "sca",
+      "id": "CVE-2026-59873",
+      "alternateId": "ztwX8omOcd2OAazCQdNBbOlmcjzrbjgTcgjZLtIi4uI=",
+      "similarityId": "CVE-2026-59873",
+      "status": "NEW",
+      "state": "TO_VERIFY",
+      "severity": "CRITICAL",
+      "confidenceLevel": 0,
+      "created": "2026-08-24T07:01:49Z",
+      "firstFoundAt": "2026-08-24T06:59:45Z",
+      "foundAt": "2026-08-24T07:01:49Z",
+      "firstScanId": "0c8fe820-b438-4614-95d3-dd7e3ffa2fe5",
+      "description": "node-tar is a tar archive manipulation library for Node.js. Prior to 7.5.19, node-tar does not enforce hard upper bounds on total decompressed data, entry counts, or decompression ratio in extraction and parsing paths such as src/extract.ts, allowing a small crafted gzip bomb to exhaust disk space and CPU. This issue is fixed in version 7.5.19.",
+      "data": {
+        "packageIdentifier": "Npm-tar-7.5.16",
+        "publishedAt": "2026-07-08T16:16:33+00:00",
+        "recommendations": "7.5.19",
+        "recommendedVersion": "7.5.19",
+        "exploitableMethods": null,
+        "packageData": [
+          {
+            "url": "https://github.com/advisories/GHSA-23hp-3jrh-7fpw",
+            "type": "Advisory"
+          },
+          {
+            "url": "https://github.com/isaacs/node-tar/security/advisories/GHSA-23hp-3jrh-7fpw",
+            "type": "Advisory"
+          },
+          {
+            "url": "https://github.com/isaacs/node-tar/commit/2812e9338665659b183aa7226518c307044957d3",
+            "type": "Commit"
+          }
+        ]
+      },
+      "comments": {
+        "comments": ""
+      },
+      "vulnerabilityDetails": {
+        "cvssScore": 9.199999809265137,
+        "cveName": "CVE-2026-59873",
+        "cweId": "CWE-770",
+        "cvss": {
+          "score": 9.2,
+          "version": 4,
+          "severity": "Critical",
+          "attackVector": "NETWORK",
+          "userInteraction": "NONE",
+          "attackComplexity": "LOW",
+          "attackRequirements": "NONE",
+          "privilegesRequired": "NONE",
+          "subsequentSystemIntegrity": "NONE",
+          "vulnerableSystemIntegrity": "NONE",
+          "subsequentSystemAvailability": "HIGH",
+          "vulnerableSystemAvailability": "HIGH",
+          "subsequentSystemConfidentiality": "NONE",
+          "vulnerableSystemConfidentiality": "NONE"
+        }
+      }
+    },
+    {
+      "type": "sca",
+      "id": "CVE-2026-53550",
+      "alternateId": "ZZL0GbM99worSFb6bfrUf73w54OTLGWV+iM9sNdGX4A=",
+      "similarityId": "CVE-2026-53550",
+      "status": "NEW",
+      "state": "TO_VERIFY",
+      "severity": "MEDIUM",
+      "confidenceLevel": 0,
+      "created": "2026-08-24T07:01:49Z",
+      "firstFoundAt": "2026-08-24T06:59:45Z",
+      "foundAt": "2026-08-24T07:01:49Z",
+      "firstScanId": "0c8fe820-b438-4614-95d3-dd7e3ffa2fe5",
+      "description": "js-yaml is a JavaScript YAML parser and dumper. Prior to 4.2.0, a crafted YAML document can trigger algorithmic CPU exhaustion in js-yaml merge-key processing (<<) by repeating the same alias many times in a merge sequence. This causes quadratic parse-time behavior relative to input size and can block a Node.js worker/event loop for seconds with a relatively small payload (tens of KB), resulting in denial of service. The issue is in merge handling inside lib/loader.js. This vulnerability is fixed in 4.2.0.",
+      "data": {
+        "packageIdentifier": "Npm-js-yaml-3.14.2",
+        "publishedAt": "2026-06-22T16:16:38+00:00",
+        "recommendations": "3.15.0",
+        "recommendedVersion": "3.15.0",
+        "exploitableMethods": null,
+        "packageData": [
+          {
+            "url": "https://github.com/advisories/GHSA-h67p-54hq-rp68",
+            "type": "Advisory"
+          }
+        ]
+      },
+      "comments": {
+        "comments": ""
+      },
+      "vulnerabilityDetails": {
+        "cvssScore": 5.300000190734863,
+        "cveName": "CVE-2026-53550",
+        "cweId": "CWE-407",
+        "cvss": {
+          "scope": "UNCHANGED",
+          "score": 5.3,
+          "version": 3,
+          "severity": "Medium",
+          "integrity": "NONE",
+          "attackVector": "NETWORK",
+          "availability": "LOW",
+          "confidentiality": "NONE",
+          "userInteraction": "NONE",
+          "attackComplexity": "LOW",
+          "privilegesRequired": "NONE"
+        }
+      }
+    }
+  ],
+  "totalCount": 25
+}


### PR DESCRIPTION
**Summary**

Updated the Azure DevOps plugin to include the Checkmarx Azure DevOps plugin version in the User-Agent for every API call made via the CLI.

**Context**

Currently, the Azure DevOps plugin logs only the Azure DevOps name in the User-Agent for API calls. The existing value is:

Azure DevOps/2.3.48

This change ensures that the Checkmarx Azure DevOps plugin version is also included in the User-Agent, making it possible to identify the plugin version associated with API requests.

**What Changed**
Updated the Azure DevOps plugin to append its plugin version to the User-Agent.
The plugin now appends _<Cx_Azure_DevOps_Plugin_version> to the existing User-Agent value.
The CLI continues to be responsible for adding the /ASTCLI_<ASTCLI_VERSION> portion.
The updated User-Agent is applied to every API call made via the CLI.